### PR TITLE
Fix Python 3.9 Tool union runtime check

### DIFF
--- a/src/agents/extensions/visualization.py
+++ b/src/agents/extensions/visualization.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import get_args
+
 import graphviz  # type: ignore
 
 from agents import Agent
@@ -139,7 +141,7 @@ def get_all_edges(
             "{agent.name}" -> "{handoff.name}";""")
             parts.append(get_all_edges(handoff, agent, visited))
 
-    if not agent.handoffs and not isinstance(agent, Tool):  # type: ignore
+    if not agent.handoffs and not isinstance(agent, get_args(Tool)):
         parts.append(f'"{agent.name}" -> "__end__";')
 
     return "".join(parts)

--- a/tests/extensions/test_visualization_tool_runtime.py
+++ b/tests/extensions/test_visualization_tool_runtime.py
@@ -1,0 +1,25 @@
+from typing import get_args
+
+from agents import Agent
+from agents.extensions.visualization import get_all_edges
+from agents.tool import FunctionTool, Tool
+
+
+def test_tool_union_expands_to_runtime_classes() -> None:
+    runtime_types = get_args(Tool)
+
+    assert runtime_types
+    assert FunctionTool in runtime_types
+    assert all(isinstance(item, type) for item in runtime_types)
+
+
+def test_get_all_edges_avoids_typing_union_isinstance_error() -> None:
+    agent = Agent(
+        name="demo_agent",
+        instructions="Test agent",
+    )
+
+    result = get_all_edges(agent)
+
+    assert isinstance(result, str)
+    assert "demo_agent" in result


### PR DESCRIPTION
## Summary

Fixes the Python 3.9 runtime crash caused by using a `typing.Union` directly in:

`isinstance(agent, Tool)`

The code now expands the union into its real runtime classes with:

`get_args(Tool)`

## Files changed

- `src/agents/extensions/visualization.py`
- `tests/extensions/test_visualization_tool_runtime.py`

## Verification

- Regression tests passed: `2 passed`
- Python syntax check passed
- `git diff --check` passed
- Python support remains `>=3.9`
- Existing GARVIS work was left untouched

## Boundary

This is a compatibility repair only. It does not change GARVIS authority, autonomy, or scientific claims.