### PR TITLE
Fix GARVIS default OpenAI model

### DIFF
--- a/src/garvis/assistant.py
+++ b/src/garvis/assistant.py
@@ -16,7 +16,7 @@ from typing import Any, Awaitable, Callable, Dict, Optional
 
 from agents import Agent, Runner, SQLiteSession
 
-DEFAULT_MODEL = "gpt-5.6-luna"
+DEFAULT_MODEL = "gpt-4.1-mini"
 DEFAULT_MAX_TURNS = 8
 
 GARVIS_INSTRUCTIONS = """

--- a/tests/garvis/test_default_model.py
+++ b/tests/garvis/test_default_model.py
@@ -1,0 +1,10 @@
+from garvis.assistant import DEFAULT_MODEL, GarvisAssistant
+
+
+def test_default_model_is_verified_api_model() -> None:
+    assert DEFAULT_MODEL == "gpt-4.1-mini"
+
+
+def test_assistant_uses_default_model_when_unspecified() -> None:
+    assistant = GarvisAssistant(persist_memory=False)
+    assert assistant.model == DEFAULT_MODEL


### PR DESCRIPTION
## Summary
- replace the invalid GARVIS default model `gpt-5.6-luna` with the verified working model `gpt-4.1-mini`
- add regression coverage confirming the default constant and fallback behavior

## Validation
- `PYTHONPATH=src python -m pytest tests/garvis -q`
- 15 tests passed

Authorship: Adrien D. Thomas