### PR TITLE
Add read-only repository grounding to GARVIS

### DIFF
--- a/src/garvis/assistant.py
+++ b/src/garvis/assistant.py
@@ -16,6 +16,8 @@ from typing import Any, Awaitable, Callable, Dict, Optional
 
 from agents import Agent, Runner, SQLiteSession
 
+from .repository_context import ground_message, should_ground_repository
+
 DEFAULT_MODEL = "gpt-4.1-mini"
 DEFAULT_MAX_TURNS = 8
 
@@ -178,6 +180,7 @@ class GarvisAssistant:
         session_db: Optional[Path] = None,
         runner: Optional[RunCallable] = None,
         session_factory: Optional[SessionFactory] = None,
+        repository_root: Optional[Path] = None,
     ) -> None:
         if max_turns < 1:
             raise ValueError("max_turns must be at least 1")
@@ -188,6 +191,7 @@ class GarvisAssistant:
         self.session_db = session_db or self._default_session_db()
         self._runner: RunCallable = runner or Runner.run
         self._session_factory = session_factory or _default_session_factory
+        self.repository_root = repository_root or Path.cwd()
         self._sessions: Dict[str, Any] = {}
         self.agent = Agent(
             name="GARVIS",
@@ -233,6 +237,9 @@ class GarvisAssistant:
                 "usefully and prepare the work, but do not claim execution. State the exact action "
                 "that requires Adrien's approval before it is performed.]"
             )
+
+        if should_ground_repository(clean_message):
+            run_input = ground_message(run_input, self.repository_root)
 
         result = await self._runner(
             self.agent,

--- a/src/garvis/repository_context.py
+++ b/src/garvis/repository_context.py
@@ -1,0 +1,71 @@
+"""Read-only repository grounding for GARVIS responses."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+GROUNDING_KEYWORDS = (
+    "architecture",
+    "code",
+    "file",
+    "implementation",
+    "repository",
+    "source",
+    "test",
+)
+
+GROUNDING_FILES = (
+    "src/garvis/assistant.py",
+    "src/garvis/cli.py",
+    "tests/garvis/test_assistant.py",
+    "tests/garvis/test_cli.py",
+    "tests/garvis/test_default_model.py",
+)
+
+MAX_FILE_CHARS = 4_000
+MAX_CONTEXT_CHARS = 14_000
+
+
+def should_ground_repository(message: str) -> bool:
+    normalized = message.casefold()
+    return any(keyword in normalized for keyword in GROUNDING_KEYWORDS)
+
+
+def build_repository_context(repository_root: Path) -> str:
+    root = repository_root.resolve()
+    sections: list[str] = []
+
+    for relative_name in GROUNDING_FILES:
+        path = root / relative_name
+        if not path.is_file():
+            continue
+
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError):
+            continue
+
+        excerpt = text[:MAX_FILE_CHARS]
+        if len(text) > MAX_FILE_CHARS:
+            excerpt += "\n[truncated]"
+
+        sections.append(f"--- {relative_name} ---\n{excerpt}")
+
+    return "\n\n".join(sections)[:MAX_CONTEXT_CHARS]
+
+
+def ground_message(message: str, repository_root: Path) -> str:
+    snapshot = build_repository_context(repository_root)
+
+    if not snapshot:
+        return message
+
+    return (
+        "[GARVIS read-only repository evidence]\n"
+        "Use only the files below when making repository claims. "
+        "Distinguish verified implementation from proposals or assumptions. "
+        "You have no permission to modify files or execute commands.\n\n"
+        f"{snapshot}\n\n"
+        "[User request]\n"
+        f"{message}"
+    )

--- a/tests/garvis/test_repository_context.py
+++ b/tests/garvis/test_repository_context.py
@@ -1,0 +1,91 @@
+from pathlib import Path
+
+import pytest
+
+from garvis.assistant import GarvisAssistant
+from garvis.repository_context import (
+    build_repository_context,
+    ground_message,
+    should_ground_repository,
+)
+
+
+class FakeResult:
+    final_output = "Grounded answer"
+
+
+class FakeRunner:
+    def __init__(self) -> None:
+        self.input = ""
+
+    async def __call__(self, agent, run_input, **kwargs):
+        self.input = run_input
+        return FakeResult()
+
+
+def test_grounding_classifier_targets_repository_questions() -> None:
+    assert should_ground_repository("Explain the repository architecture")
+    assert should_ground_repository("What tests exist?")
+    assert not should_ground_repository("What is the weather?")
+
+
+def test_snapshot_reads_only_allowlisted_files(tmp_path: Path) -> None:
+    allowed = tmp_path / "src" / "garvis" / "assistant.py"
+    allowed.parent.mkdir(parents=True)
+    allowed.write_text("ACTIVE_ASSISTANT")
+
+    secret = tmp_path / "secret.txt"
+    secret.write_text("DO_NOT_INCLUDE")
+
+    snapshot = build_repository_context(tmp_path)
+
+    assert "ACTIVE_ASSISTANT" in snapshot
+    assert "DO_NOT_INCLUDE" not in snapshot
+
+
+def test_ground_message_labels_repository_evidence(tmp_path: Path) -> None:
+    allowed = tmp_path / "src" / "garvis" / "cli.py"
+    allowed.parent.mkdir(parents=True)
+    allowed.write_text("ACTIVE_CLI")
+
+    grounded = ground_message("Explain the code", tmp_path)
+
+    assert "[GARVIS read-only repository evidence]" in grounded
+    assert "ACTIVE_CLI" in grounded
+    assert "[User request]" in grounded
+
+
+@pytest.mark.asyncio
+async def test_repository_question_receives_grounded_context(tmp_path: Path) -> None:
+    allowed = tmp_path / "src" / "garvis" / "assistant.py"
+    allowed.parent.mkdir(parents=True)
+    allowed.write_text("VERIFIED_IMPLEMENTATION")
+
+    runner = FakeRunner()
+    assistant = GarvisAssistant(
+        runner=runner,
+        persist_memory=False,
+        repository_root=tmp_path,
+    )
+
+    reply = await assistant.respond("Explain this repository architecture")
+
+    assert reply.text == "Grounded answer"
+    assert "VERIFIED_IMPLEMENTATION" in runner.input
+    assert "read-only repository evidence" in runner.input
+
+
+@pytest.mark.asyncio
+async def test_ordinary_question_is_not_given_repository_snapshot(
+    tmp_path: Path,
+) -> None:
+    runner = FakeRunner()
+    assistant = GarvisAssistant(
+        runner=runner,
+        persist_memory=False,
+        repository_root=tmp_path,
+    )
+
+    await assistant.respond("Is the heartbeat operating?")
+
+    assert runner.input == "Is the heartbeat operating?"


### PR DESCRIPTION
## Summary
- add a bounded, read-only repository evidence snapshot for GARVIS
- ground repository, code, architecture, file, source, implementation, and test questions in active GARVIS files
- preserve the approval boundary: no command execution and no file modification
- add tests for allowlisting, evidence labeling, grounded questions, and ordinary ungrounded questions

## Validation
- `PYTHONPATH=src python -m pytest tests/garvis -q`
- 20 tests passed

Authorship: Adrien D. Thomas