### PR TITLE
Add read-only Hypercube snapshot validation

### DIFF
--- a/src/garvis/hypercube_snapshot.py
+++ b/src/garvis/hypercube_snapshot.py
@@ -1,0 +1,101 @@
+"""Read-only validation and loading of Hypercube cognitive-cycle snapshots."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+
+REQUIRED_CYCLE_FIELDS = frozenset(
+    {
+        "cycle_id",
+        "cycle_version",
+        "status",
+        "stage",
+        "operator_context",
+        "input_state",
+        "observation_summary",
+        "candidate_thoughts",
+        "comparison",
+        "selection",
+        "uncertainty",
+        "evolution_contract",
+        "next_smallest_step",
+        "output_boundary",
+    }
+)
+
+
+class HypercubeSnapshotError(ValueError):
+    """Raised when Hypercube snapshot evidence is missing or invalid."""
+
+
+def validate_hypercube_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate a cognitive-cycle snapshot without modifying it or its source."""
+
+    missing = sorted(REQUIRED_CYCLE_FIELDS.difference(snapshot))
+    if missing:
+        raise HypercubeSnapshotError(
+            "Hypercube snapshot is missing required fields: " + ", ".join(missing)
+        )
+
+    cycle_id = snapshot["cycle_id"]
+    if not isinstance(cycle_id, str) or not cycle_id.strip():
+        raise HypercubeSnapshotError("Hypercube snapshot cycle_id must be a non-empty string")
+
+    candidate_thoughts = snapshot["candidate_thoughts"]
+    if not isinstance(candidate_thoughts, list):
+        raise HypercubeSnapshotError(
+            "Hypercube snapshot candidate_thoughts must be an array"
+        )
+
+    for field in (
+        "operator_context",
+        "input_state",
+        "observation_summary",
+        "comparison",
+        "selection",
+        "uncertainty",
+        "evolution_contract",
+        "next_smallest_step",
+        "output_boundary",
+    ):
+        if not isinstance(snapshot[field], dict):
+            raise HypercubeSnapshotError(
+                f"Hypercube snapshot {field} must be an object"
+            )
+
+    return dict(snapshot)
+
+
+def load_hypercube_snapshot(path: Path | str) -> dict[str, Any]:
+    """Load and validate an existing JSON snapshot using read-only file access."""
+
+    snapshot_path = Path(path)
+
+    if not snapshot_path.is_file():
+        raise HypercubeSnapshotError(
+            f"Hypercube snapshot file was not found: {snapshot_path}"
+        )
+
+    try:
+        raw_text = snapshot_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise HypercubeSnapshotError(
+            f"Hypercube snapshot could not be read: {snapshot_path}"
+        ) from exc
+
+    try:
+        payload = json.loads(raw_text)
+    except json.JSONDecodeError as exc:
+        raise HypercubeSnapshotError(
+            f"Hypercube snapshot is not valid JSON: {snapshot_path}"
+        ) from exc
+
+    if not isinstance(payload, dict):
+        raise HypercubeSnapshotError(
+            "Hypercube snapshot must contain a top-level JSON object"
+        )
+
+    return validate_hypercube_snapshot(payload)

--- a/tests/garvis/test_hypercube_snapshot.py
+++ b/tests/garvis/test_hypercube_snapshot.py
@@ -1,0 +1,75 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from garvis.hypercube_snapshot import (
+    HypercubeSnapshotError,
+    load_hypercube_snapshot,
+    validate_hypercube_snapshot,
+)
+
+
+def valid_snapshot() -> dict:
+    return {
+        "cycle_id": "cycle-001",
+        "cycle_version": "1.0",
+        "status": "draft",
+        "stage": "stage 2 cognitive draft",
+        "operator_context": {},
+        "input_state": {},
+        "observation_summary": {},
+        "candidate_thoughts": [],
+        "comparison": {},
+        "selection": {},
+        "uncertainty": {},
+        "evolution_contract": {},
+        "next_smallest_step": {},
+        "output_boundary": {},
+    }
+
+
+def test_valid_snapshot_is_accepted() -> None:
+    snapshot = valid_snapshot()
+
+    validated = validate_hypercube_snapshot(snapshot)
+
+    assert validated == snapshot
+    assert validated is not snapshot
+
+
+def test_missing_required_field_is_rejected() -> None:
+    snapshot = valid_snapshot()
+    del snapshot["output_boundary"]
+
+    with pytest.raises(
+        HypercubeSnapshotError,
+        match="missing required fields: output_boundary",
+    ):
+        validate_hypercube_snapshot(snapshot)
+
+
+def test_snapshot_file_is_loaded_read_only(tmp_path: Path) -> None:
+    snapshot_path = tmp_path / "latest_cognitive_cycle.json"
+    original_text = json.dumps(valid_snapshot(), sort_keys=True)
+    snapshot_path.write_text(original_text, encoding="utf-8")
+
+    loaded = load_hypercube_snapshot(snapshot_path)
+
+    assert loaded["cycle_id"] == "cycle-001"
+    assert snapshot_path.read_text(encoding="utf-8") == original_text
+
+
+def test_missing_snapshot_file_has_clear_error(tmp_path: Path) -> None:
+    missing_path = tmp_path / "latest_cognitive_cycle.json"
+
+    with pytest.raises(HypercubeSnapshotError, match="file was not found"):
+        load_hypercube_snapshot(missing_path)
+
+
+def test_invalid_json_is_rejected(tmp_path: Path) -> None:
+    snapshot_path = tmp_path / "latest_cognitive_cycle.json"
+    snapshot_path.write_text("{not-json", encoding="utf-8")
+
+    with pytest.raises(HypercubeSnapshotError, match="not valid JSON"):
+        load_hypercube_snapshot(snapshot_path)

--- a/tests/garvis/test_hypercube_snapshot.py
+++ b/tests/garvis/test_hypercube_snapshot.py
@@ -10,7 +10,7 @@ from garvis.hypercube_snapshot import (
 )
 
 
-def valid_snapshot() -> dict:
+def valid_snapshot() -> dict[str, object]:
     return {
         "cycle_id": "cycle-001",
         "cycle_version": "1.0",


### PR DESCRIPTION
## Summary

- add a read-only loader for Hypercube cognitive-cycle JSON snapshots
- validate the official required cognitive-cycle fields
- reject missing files, invalid JSON, missing fields, and invalid structures
- do not run Hypercube automatically
- do not modify Hypercube evidence

## Verification

- 5 targeted snapshot tests passed
- 25 full GARVIS tests passed
- git diff --check passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for Hypercube cognitive-cycle snapshot data, including required fields and value types.
  * Added support for loading and validating snapshot JSON files.
  * Added clear errors for missing files, invalid JSON, malformed data, and incomplete snapshots.
  * Snapshot validation is read-only and does not modify the original data or file contents.

* **Tests**
  * Added coverage for valid snapshots, validation errors, file loading, missing files, and invalid JSON.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->