### PR TITLE
Require Hypercube power request governance fields

### DIFF
--- a/src/garvis/hypercube_snapshot.py
+++ b/src/garvis/hypercube_snapshot.py
@@ -23,6 +23,7 @@ REQUIRED_CYCLE_FIELDS = frozenset(
         "evolution_contract",
         "next_smallest_step",
         "output_boundary",
+        "power_request",
     }
 )
 
@@ -60,11 +61,53 @@ def validate_hypercube_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
         "evolution_contract",
         "next_smallest_step",
         "output_boundary",
+        "power_request",
     ):
         if not isinstance(snapshot[field], dict):
             raise HypercubeSnapshotError(
                 f"Hypercube snapshot {field} must be an object"
             )
+
+    power_request = snapshot["power_request"]
+    required_power_fields = {
+        "power_requested",
+        "requested_permissions",
+        "why_power_should_be_refused",
+        "approval_required",
+        "ledger_required",
+    }
+    missing_power_fields = sorted(required_power_fields.difference(power_request))
+    if missing_power_fields:
+        raise HypercubeSnapshotError(
+            "Hypercube snapshot power_request is missing required fields: "
+            + ", ".join(missing_power_fields)
+        )
+
+    if not isinstance(power_request["power_requested"], bool):
+        raise HypercubeSnapshotError(
+            "Hypercube snapshot power_request.power_requested must be a boolean"
+        )
+
+    if not isinstance(power_request["requested_permissions"], list):
+        raise HypercubeSnapshotError(
+            "Hypercube snapshot power_request.requested_permissions must be an array"
+        )
+
+    if not isinstance(power_request["why_power_should_be_refused"], str):
+        raise HypercubeSnapshotError(
+            "Hypercube snapshot power_request.why_power_should_be_refused "
+            "must be a string"
+        )
+
+    if not isinstance(power_request["approval_required"], bool):
+        raise HypercubeSnapshotError(
+            "Hypercube snapshot power_request.approval_required must be a boolean"
+        )
+
+    if not isinstance(power_request["ledger_required"], bool):
+        raise HypercubeSnapshotError(
+            "Hypercube snapshot power_request.ledger_required must be a boolean"
+        )
 
     return dict(snapshot)
 

--- a/tests/garvis/test_hypercube_snapshot.py
+++ b/tests/garvis/test_hypercube_snapshot.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -10,7 +11,7 @@ from garvis.hypercube_snapshot import (
 )
 
 
-def valid_snapshot() -> dict[str, object]:
+def valid_snapshot() -> dict[str, Any]:
     return {
         "cycle_id": "cycle-001",
         "cycle_version": "1.0",

--- a/tests/garvis/test_hypercube_snapshot.py
+++ b/tests/garvis/test_hypercube_snapshot.py
@@ -26,6 +26,13 @@ def valid_snapshot() -> dict[str, object]:
         "evolution_contract": {},
         "next_smallest_step": {},
         "output_boundary": {},
+        "power_request": {
+            "power_requested": False,
+            "requested_permissions": [],
+            "why_power_should_be_refused": "",
+            "approval_required": False,
+            "ledger_required": False,
+        },
     }
 
 
@@ -73,3 +80,35 @@ def test_invalid_json_is_rejected(tmp_path: Path) -> None:
 
     with pytest.raises(HypercubeSnapshotError, match="not valid JSON"):
         load_hypercube_snapshot(snapshot_path)
+
+def test_missing_power_request_is_rejected() -> None:
+    snapshot = valid_snapshot()
+    del snapshot["power_request"]
+
+    with pytest.raises(
+        HypercubeSnapshotError,
+        match="missing required fields: power_request",
+    ):
+        validate_hypercube_snapshot(snapshot)
+
+
+def test_incomplete_power_request_is_rejected() -> None:
+    snapshot = valid_snapshot()
+    del snapshot["power_request"]["approval_required"]
+
+    with pytest.raises(
+        HypercubeSnapshotError,
+        match="power_request is missing required fields: approval_required",
+    ):
+        validate_hypercube_snapshot(snapshot)
+
+
+def test_power_request_field_types_are_validated() -> None:
+    snapshot = valid_snapshot()
+    snapshot["power_request"]["requested_permissions"] = "repository-write"
+
+    with pytest.raises(
+        HypercubeSnapshotError,
+        match="requested_permissions must be an array",
+    ):
+        validate_hypercube_snapshot(snapshot)


### PR DESCRIPTION
## Summary

- require the official Hypercube `power_request` field
- validate all five governance fields inside `power_request`
- reject missing or malformed approval-governance data
- align GARVIS snapshot validation with the authoritative Hypercube schema

## Verification

- 8 targeted snapshot tests passed
- 28 full GARVIS tests passed
- git diff --check passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for cognitive-cycle snapshots by requiring complete power-request details.
  * Snapshots are now rejected when power-request information is missing, incomplete, or uses invalid field types.

* **Tests**
  * Added coverage for missing, incomplete, and incorrectly formatted power-request data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->