### PR TITLE
Add immutable GARVIS evidence envelope

### DIFF
--- a/src/garvis/evidence_envelope.py
+++ b/src/garvis/evidence_envelope.py
@@ -1,0 +1,184 @@
+"""Read-only evidence envelope for GARVIS system data.
+
+This module keeps validated source evidence separate from GARVIS-generated
+inference, symbolic interpretation, speculation, and unknowns.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass, field, replace
+from types import MappingProxyType
+from typing import Any
+
+from garvis.hypercube_snapshot import (
+    HypercubeSnapshotError,
+    validate_hypercube_snapshot,
+)
+
+
+# Stable validation seam for tests and future read-only integrations.
+validate_snapshot = validate_hypercube_snapshot
+
+
+
+class FrozenList(tuple):
+    """Immutable sequence that retains JSON-list equality semantics."""
+
+    def __new__(cls, values: Any = ()) -> "FrozenList":
+        return super().__new__(cls, values)
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, (list, tuple)):
+            return list(self) == list(other)
+        return False
+
+    __hash__ = tuple.__hash__
+
+
+def _freeze(value: Any) -> Any:
+    """Recursively convert mutable containers into immutable equivalents."""
+
+    if isinstance(value, Mapping):
+        return MappingProxyType(
+            {key: _freeze(item) for key, item in value.items()}
+        )
+
+    if isinstance(value, list):
+        return FrozenList(_freeze(item) for item in value)
+
+    if isinstance(value, tuple):
+        return FrozenList(_freeze(item) for item in value)
+
+    if isinstance(value, set):
+        return frozenset(_freeze(item) for item in value)
+
+    return value
+
+
+def _plain(value: Any) -> Any:
+    """Convert immutable containers into JSON-serializable plain values."""
+
+    if isinstance(value, Mapping):
+        return {key: _plain(item) for key, item in value.items()}
+
+    if isinstance(value, tuple):
+        return [_plain(item) for item in value]
+
+    if isinstance(value, frozenset):
+        return sorted(_plain(item) for item in value)
+
+    return value
+
+
+@dataclass(frozen=True)
+class EvidenceEnvelope:
+    """Immutable container separating evidence from generated interpretation."""
+
+    immutable_source_evidence: Mapping[str, Any] = field(default_factory=dict)
+    hypercube_cycle_data: Mapping[str, Any] | None = None
+    deterministic_agi_measurements: Mapping[str, Any] = field(
+        default_factory=dict
+    )
+    scientific_claims: Mapping[str, Any] = field(default_factory=dict)
+    source_provenance_hashes: Mapping[str, Any] = field(default_factory=dict)
+    approval_state: Mapping[str, Any] = field(default_factory=dict)
+    garvis_evidence_summary: Mapping[str, Any] = field(default_factory=dict)
+    engineering_inference: Mapping[str, Any] = field(default_factory=dict)
+    symbolic_interpretation: Mapping[str, Any] = field(default_factory=dict)
+    unsupported_speculation: Mapping[str, Any] = field(default_factory=dict)
+    unknowns: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.hypercube_cycle_data is not None:
+            try:
+                validate_snapshot(self.hypercube_cycle_data)
+            except HypercubeSnapshotError as exc:
+                raise ValueError(
+                    f"Invalid hypercube_cycle_data provided: {exc}"
+                ) from exc
+
+        immutable_fields = (
+            "immutable_source_evidence",
+            "hypercube_cycle_data",
+            "deterministic_agi_measurements",
+            "scientific_claims",
+            "source_provenance_hashes",
+            "approval_state",
+            "garvis_evidence_summary",
+            "engineering_inference",
+            "symbolic_interpretation",
+            "unsupported_speculation",
+            "unknowns",
+        )
+
+        for field_name in immutable_fields:
+            value = getattr(self, field_name)
+
+            if value is not None:
+                object.__setattr__(self, field_name, _freeze(value))
+
+    def compute_sha256_hash(self, data: Any) -> str:
+        """Compute a deterministic SHA-256 hash for JSON-compatible data."""
+
+        encoded = json.dumps(
+            _plain(data),
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+
+        return hashlib.sha256(encoded).hexdigest()
+
+    def with_source_provenance(
+        self,
+        source_key: str,
+        source_data: Any,
+    ) -> EvidenceEnvelope:
+        """Return a new envelope containing a source-provenance hash."""
+
+        updated_hashes = dict(self.source_provenance_hashes)
+        updated_hashes[source_key] = self.compute_sha256_hash(source_data)
+
+        return replace(
+            self,
+            source_provenance_hashes=updated_hashes,
+        )
+
+
+def build_evidence_envelope(
+    *,
+    immutable_source_evidence: Mapping[str, Any],
+    hypercube_cycle_data: Mapping[str, Any] | None = None,
+    deterministic_agi_measurements: Mapping[str, Any] | None = None,
+    scientific_claims: Mapping[str, Any] | None = None,
+    source_provenance_hashes: Mapping[str, Any] | None = None,
+    approval_state: Mapping[str, Any] | None = None,
+    garvis_evidence_summary: Mapping[str, Any] | None = None,
+    engineering_inference: Mapping[str, Any] | None = None,
+    symbolic_interpretation: Mapping[str, Any] | None = None,
+    unsupported_speculation: Mapping[str, Any] | None = None,
+    unknowns: Mapping[str, Any] | None = None,
+) -> EvidenceEnvelope:
+    """Build an immutable evidence envelope from read-only input records."""
+
+    return EvidenceEnvelope(
+        immutable_source_evidence=dict(immutable_source_evidence),
+        hypercube_cycle_data=(
+            None
+            if hypercube_cycle_data is None
+            else dict(hypercube_cycle_data)
+        ),
+        deterministic_agi_measurements=dict(
+            deterministic_agi_measurements or {}
+        ),
+        scientific_claims=dict(scientific_claims or {}),
+        source_provenance_hashes=dict(source_provenance_hashes or {}),
+        approval_state=dict(approval_state or {}),
+        garvis_evidence_summary=dict(garvis_evidence_summary or {}),
+        engineering_inference=dict(engineering_inference or {}),
+        symbolic_interpretation=dict(symbolic_interpretation or {}),
+        unsupported_speculation=dict(unsupported_speculation or {}),
+        unknowns=dict(unknowns or {}),
+    )

--- a/tests/garvis/test_evidence_envelope.py
+++ b/tests/garvis/test_evidence_envelope.py
@@ -6,7 +6,6 @@ import pytest
 from garvis.evidence_envelope import (
     EvidenceEnvelope,
     build_evidence_envelope,
-    validate_snapshot,
 )
 
 

--- a/tests/garvis/test_evidence_envelope.py
+++ b/tests/garvis/test_evidence_envelope.py
@@ -1,0 +1,73 @@
+import pytest
+from garvis.evidence_envelope import build_evidence_envelope, EvidenceEnvelope, validate_snapshot
+from typing import Any
+
+
+def valid_snapshot() -> dict[str, Any]:
+    return {
+        "cycle_id": "cycle-001",
+        "cycle_version": "1.0",
+        "status": "draft",
+        "stage": "stage 2 cognitive draft",
+        "operator_context": {},
+        "input_state": {},
+        "observation_summary": {},
+        "candidate_thoughts": [],
+        "comparison": {},
+        "selection": {},
+        "uncertainty": {},
+        "evolution_contract": {},
+        "next_smallest_step": {},
+        "output_boundary": {},
+        "power_request": {
+            "power_requested": False,
+            "requested_permissions": [],
+            "why_power_should_be_refused": "",
+            "approval_required": False,
+            "ledger_required": False,
+        },
+    }
+
+
+def test_build_basic_envelope():
+    immutable_data = {"source": "immutable source data"}
+    hypercube_data = valid_snapshot()
+
+    envelope = build_evidence_envelope(
+        immutable_source_evidence=immutable_data,
+        hypercube_cycle_data=hypercube_data,
+    )
+
+    assert isinstance(envelope, EvidenceEnvelope)
+    assert envelope.immutable_source_evidence == immutable_data
+    assert envelope.hypercube_cycle_data == hypercube_data
+
+
+def test_invalid_hypercube_raises():
+    with pytest.raises(ValueError):
+        build_evidence_envelope(
+            immutable_source_evidence={},
+            hypercube_cycle_data={"cycle_id": "incomplete"},
+        )
+
+
+def test_source_provenance_hashing():
+    immutable_data = {"field": "value"}
+
+    envelope = build_evidence_envelope(immutable_source_evidence=immutable_data)
+
+    hashed = envelope.compute_sha256_hash(immutable_data)
+
+    new_envelope = envelope.with_source_provenance("test_source", immutable_data)
+
+    assert "test_source" in new_envelope.source_provenance_hashes
+    assert new_envelope.source_provenance_hashes["test_source"] == hashed
+    assert new_envelope != envelope
+
+
+def test_immutable_properties():
+    envelope = build_evidence_envelope(immutable_source_evidence={})
+    with pytest.raises(Exception):
+        envelope.immutable_source_evidence["new"] = "forbidden"
+    with pytest.raises(Exception):
+        envelope.hypercube_cycle_data = {}

--- a/tests/garvis/test_evidence_envelope.py
+++ b/tests/garvis/test_evidence_envelope.py
@@ -1,6 +1,13 @@
+from dataclasses import FrozenInstanceError
+from typing import Any, cast
+
 import pytest
-from garvis.evidence_envelope import build_evidence_envelope, EvidenceEnvelope, validate_snapshot
-from typing import Any
+
+from garvis.evidence_envelope import (
+    EvidenceEnvelope,
+    build_evidence_envelope,
+    validate_snapshot,
+)
 
 
 def valid_snapshot() -> dict[str, Any]:
@@ -29,7 +36,7 @@ def valid_snapshot() -> dict[str, Any]:
     }
 
 
-def test_build_basic_envelope():
+def test_build_basic_envelope() -> None:
     immutable_data = {"source": "immutable source data"}
     hypercube_data = valid_snapshot()
 
@@ -43,7 +50,7 @@ def test_build_basic_envelope():
     assert envelope.hypercube_cycle_data == hypercube_data
 
 
-def test_invalid_hypercube_raises():
+def test_invalid_hypercube_raises() -> None:
     with pytest.raises(ValueError):
         build_evidence_envelope(
             immutable_source_evidence={},
@@ -51,23 +58,48 @@ def test_invalid_hypercube_raises():
         )
 
 
-def test_source_provenance_hashing():
+def test_source_provenance_hashing() -> None:
     immutable_data = {"field": "value"}
 
-    envelope = build_evidence_envelope(immutable_source_evidence=immutable_data)
+    envelope = build_evidence_envelope(
+        immutable_source_evidence=immutable_data,
+    )
 
     hashed = envelope.compute_sha256_hash(immutable_data)
-
-    new_envelope = envelope.with_source_provenance("test_source", immutable_data)
+    new_envelope = envelope.with_source_provenance(
+        "test_source",
+        immutable_data,
+    )
 
     assert "test_source" in new_envelope.source_provenance_hashes
     assert new_envelope.source_provenance_hashes["test_source"] == hashed
-    assert new_envelope != envelope
+    assert new_envelope is not envelope
 
 
-def test_immutable_properties():
-    envelope = build_evidence_envelope(immutable_source_evidence={})
-    with pytest.raises(Exception):
-        envelope.immutable_source_evidence["new"] = "forbidden"
-    with pytest.raises(Exception):
-        envelope.hypercube_cycle_data = {}
+def test_immutable_properties() -> None:
+    envelope = build_evidence_envelope(
+        immutable_source_evidence={
+            "nested": {
+                "values": [1, 2, {"state": "measured"}],
+            }
+        }
+    )
+
+    source = cast(Any, envelope.immutable_source_evidence)
+
+    with pytest.raises(TypeError):
+        source["new"] = "forbidden"
+
+    with pytest.raises(TypeError):
+        source["nested"]["values"][2]["state"] = "changed"
+
+    with pytest.raises(AttributeError):
+        source["nested"]["values"].append(3)
+
+    mutable_envelope = cast(Any, envelope)
+
+    with pytest.raises(FrozenInstanceError):
+        mutable_envelope.hypercube_cycle_data = {}
+
+    with pytest.raises(FrozenInstanceError):
+        mutable_envelope.immutable_source_evidence = {}


### PR DESCRIPTION
## Summary

Adds a read-only evidence envelope for GARVIS that separates:

- immutable source evidence
- validated Hypercube cycle data
- deterministic AGI measurements
- scientific claims
- provenance hashes
- approval state
- GARVIS evidence summaries
- engineering inference
- symbolic interpretation
- unsupported speculation
- unknowns

## Safety boundaries

- Recursively blocks mutation of source records.
- Validates Hypercube snapshots before inclusion.
- Preserves SHA-256 source provenance.
- Does not grant execution, commit, push, merge, deployment, or external-action authority.
- Does not claim consciousness, sentience, true AGI, or a demonstrated Fibonacci heartbeat.
- Adrien D. Thomas remains final merge and action authority.

## Validation

- 32 GARVIS tests passed.
- 8 Hypercube snapshot tests passed.
- 4 evidence-envelope tests passed.
- Syntax validation passed.
- Staged diff check passed.
- Credential scan passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced immutable evidence envelopes to securely organize source evidence, measurements, claims, interpretations, and unknowns.
  * Added snapshot validation for hypercube cycle data with clear error handling.
  * Added deterministic SHA-256 hashing and source provenance tracking, plus helpers for safely normalizing nested evidence into JSON-compatible formats.
* **Bug Fixes**
  * Prevented accidental modification of envelope contents after creation.
* **Tests**
  * Added coverage for envelope creation, validation errors, hashing/provenance behavior, and immutability protections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->