### PR TITLE
Add bounded GitHub maintenance adapter

### DIFF
--- a/src/garvis/github_maintenance.py
+++ b/src/garvis/github_maintenance.py
@@ -1,0 +1,483 @@
+"""Bounded Git and GitHub maintenance operations for GARVIS.
+
+The adapter supports repository inspection and explicitly approved feature
+branch maintenance. It blocks main-branch pushes, force pushes, destructive
+Git operations, credential files, merges, deployments, and account changes.
+
+Adrien D. Thomas retains final merge and external-action authority.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Mapping, Optional, Sequence, Tuple
+
+
+class MaintenancePolicyError(ValueError):
+    """Raised when a requested maintenance operation violates policy."""
+
+
+class MaintenanceCommandError(RuntimeError):
+    """Raised when an approved command fails."""
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    """Immutable result of a maintenance command."""
+
+    command: Tuple[str, ...]
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+@dataclass(frozen=True)
+class RepositoryInspection:
+    """Read-only summary of one Git repository."""
+
+    repository: str
+    branch: str
+    status: str
+    latest_commit: str
+    remotes: str
+
+
+_BLOCKED_BRANCHES = frozenset(
+    {
+        "main",
+        "master",
+        "production",
+        "prod",
+        "release",
+    }
+)
+
+_BLOCKED_PATH_NAMES = frozenset(
+    {
+        ".env",
+        "openai.env",
+        "credentials.json",
+        "secrets.json",
+        "id_rsa",
+        "id_ed25519",
+        ".npmrc",
+        ".pypirc",
+    }
+)
+
+_BLOCKED_PATH_PARTS = frozenset(
+    {
+        ".git",
+        ".ssh",
+        ".gnupg",
+        "__pycache__",
+        ".venv",
+        "venv",
+        "node_modules",
+    }
+)
+
+_BLOCKED_ARGUMENTS = frozenset(
+    {
+        "--force",
+        "-f",
+        "--force-with-lease",
+        "--mirror",
+        "--delete",
+        "--hard",
+    }
+)
+
+
+def _safe_environment() -> Dict[str, str]:
+    """Return a subprocess environment without common credential variables."""
+
+    environment = dict(os.environ)
+
+    blocked_names = {
+        "OPENAI_API_KEY",
+        "PROD_OPENAI_KEY",
+        "GITHUB_TOKEN",
+        "GH_TOKEN",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "GOOGLE_APPLICATION_CREDENTIALS",
+    }
+
+    for name in blocked_names:
+        environment.pop(name, None)
+
+    return environment
+
+
+def _validate_repository(repository: Path) -> Path:
+    resolved = repository.expanduser().resolve()
+
+    if not resolved.is_dir():
+        raise MaintenancePolicyError(
+            f"Repository directory does not exist: {resolved}"
+        )
+
+    git_marker = resolved / ".git"
+    if not git_marker.exists():
+        result = subprocess.run(
+            ["git", "-C", str(resolved), "rev-parse", "--is-inside-work-tree"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=15,
+            env=_safe_environment(),
+        )
+        if result.returncode != 0:
+            raise MaintenancePolicyError(
+                f"Path is not a Git repository: {resolved}"
+            )
+
+    return resolved
+
+
+def _validate_feature_branch(branch: str) -> str:
+    cleaned = branch.strip()
+
+    if not cleaned:
+        raise MaintenancePolicyError("Branch name must not be empty")
+
+    if cleaned.lower() in _BLOCKED_BRANCHES:
+        raise MaintenancePolicyError(
+            f"Protected branch cannot be modified: {cleaned}"
+        )
+
+    if cleaned.startswith("-"):
+        raise MaintenancePolicyError("Branch name cannot begin with '-'")
+
+    return cleaned
+
+
+def _validate_relative_path(repository: Path, relative_path: str) -> str:
+    candidate = Path(relative_path)
+
+    if candidate.is_absolute():
+        raise MaintenancePolicyError(
+            f"Only repository-relative paths are allowed: {relative_path}"
+        )
+
+    if any(part in {"", ".", ".."} for part in candidate.parts):
+        raise MaintenancePolicyError(
+            f"Unsafe repository path: {relative_path}"
+        )
+
+    if any(part in _BLOCKED_PATH_PARTS for part in candidate.parts):
+        raise MaintenancePolicyError(
+            f"Blocked repository path: {relative_path}"
+        )
+
+    if candidate.name.lower() in _BLOCKED_PATH_NAMES:
+        raise MaintenancePolicyError(
+            f"Credential or secret path is blocked: {relative_path}"
+        )
+
+    resolved = (repository / candidate).resolve()
+
+    try:
+        resolved.relative_to(repository)
+    except ValueError as exc:
+        raise MaintenancePolicyError(
+            f"Path escapes repository: {relative_path}"
+        ) from exc
+
+    return candidate.as_posix()
+
+
+class GitHubMaintenanceAdapter:
+    """Execute allowlisted Git and GitHub maintenance operations."""
+
+    def __init__(self, timeout_seconds: int = 60) -> None:
+        if timeout_seconds < 1:
+            raise MaintenancePolicyError(
+                "timeout_seconds must be greater than zero"
+            )
+
+        self.timeout_seconds = timeout_seconds
+
+    def _run(
+        self,
+        command: Sequence[str],
+        cwd: Optional[Path] = None,
+    ) -> CommandResult:
+        if not command:
+            raise MaintenancePolicyError("Command must not be empty")
+
+        if any(argument in _BLOCKED_ARGUMENTS for argument in command):
+            raise MaintenancePolicyError(
+                "Force, destructive, or deletion arguments are blocked"
+            )
+
+        completed = subprocess.run(
+            list(command),
+            cwd=str(cwd) if cwd is not None else None,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=self.timeout_seconds,
+            env=_safe_environment(),
+        )
+
+        result = CommandResult(
+            command=tuple(command),
+            returncode=completed.returncode,
+            stdout=completed.stdout,
+            stderr=completed.stderr,
+        )
+
+        if completed.returncode != 0:
+            raise MaintenanceCommandError(
+                "Command failed with exit code "
+                f"{completed.returncode}: {' '.join(command)}\n"
+                f"{completed.stderr.strip()}"
+            )
+
+        return result
+
+    def inspect_repository(
+        self,
+        repository: Path,
+    ) -> RepositoryInspection:
+        """Inspect repository state without changing files or remote state."""
+
+        repo = _validate_repository(repository)
+
+        branch = self._run(
+            ["git", "branch", "--show-current"],
+            cwd=repo,
+        ).stdout.strip()
+
+        status = self._run(
+            ["git", "status", "--short"],
+            cwd=repo,
+        ).stdout
+
+        latest_commit = self._run(
+            ["git", "log", "-1", "--oneline"],
+            cwd=repo,
+        ).stdout.strip()
+
+        remotes = self._run(
+            ["git", "remote", "-v"],
+            cwd=repo,
+        ).stdout
+
+        return RepositoryInspection(
+            repository=str(repo),
+            branch=branch,
+            status=status,
+            latest_commit=latest_commit,
+            remotes=remotes,
+        )
+
+    def list_pull_requests(
+        self,
+        github_repository: str,
+        limit: int = 30,
+    ) -> CommandResult:
+        """List pull requests through the authenticated GitHub CLI."""
+
+        if "/" not in github_repository:
+            raise MaintenancePolicyError(
+                "GitHub repository must use owner/name format"
+            )
+
+        if limit < 1 or limit > 100:
+            raise MaintenancePolicyError(
+                "Pull-request limit must be between 1 and 100"
+            )
+
+        return self._run(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--repo",
+                github_repository,
+                "--limit",
+                str(limit),
+                "--json",
+                "number,title,state,headRefName,baseRefName,url",
+            ]
+        )
+
+    def list_workflow_runs(
+        self,
+        github_repository: str,
+        limit: int = 20,
+    ) -> CommandResult:
+        """List recent GitHub Actions runs without changing them."""
+
+        if "/" not in github_repository:
+            raise MaintenancePolicyError(
+                "GitHub repository must use owner/name format"
+            )
+
+        if limit < 1 or limit > 100:
+            raise MaintenancePolicyError(
+                "Workflow-run limit must be between 1 and 100"
+            )
+
+        return self._run(
+            [
+                "gh",
+                "run",
+                "list",
+                "--repo",
+                github_repository,
+                "--limit",
+                str(limit),
+                "--json",
+                "databaseId,name,status,conclusion,headBranch,url",
+            ]
+        )
+
+    def commit_feature_changes(
+        self,
+        repository: Path,
+        branch: str,
+        relative_paths: Sequence[str],
+        message: str,
+        approved: bool,
+    ) -> CommandResult:
+        """Stage exact files and create a commit on an approved feature branch."""
+
+        if not approved:
+            raise MaintenancePolicyError(
+                "Explicit approval is required before committing"
+            )
+
+        repo = _validate_repository(repository)
+        expected_branch = _validate_feature_branch(branch)
+
+        current_branch = self._run(
+            ["git", "branch", "--show-current"],
+            cwd=repo,
+        ).stdout.strip()
+
+        if current_branch != expected_branch:
+            raise MaintenancePolicyError(
+                "Current branch does not match the approved feature branch"
+            )
+
+        if not relative_paths:
+            raise MaintenancePolicyError(
+                "At least one reviewed path is required"
+            )
+
+        safe_paths = [
+            _validate_relative_path(repo, path)
+            for path in relative_paths
+        ]
+
+        cleaned_message = message.strip()
+        if not cleaned_message:
+            raise MaintenancePolicyError(
+                "Commit message must not be empty"
+            )
+
+        self._run(
+            ["git", "add", "--", *safe_paths],
+            cwd=repo,
+        )
+
+        return self._run(
+            ["git", "commit", "-m", cleaned_message],
+            cwd=repo,
+        )
+
+    def push_feature_branch(
+        self,
+        repository: Path,
+        branch: str,
+        approved: bool,
+    ) -> CommandResult:
+        """Push an explicitly approved feature branch without force."""
+
+        if not approved:
+            raise MaintenancePolicyError(
+                "Explicit approval is required before pushing"
+            )
+
+        repo = _validate_repository(repository)
+        safe_branch = _validate_feature_branch(branch)
+
+        current_branch = self._run(
+            ["git", "branch", "--show-current"],
+            cwd=repo,
+        ).stdout.strip()
+
+        if current_branch != safe_branch:
+            raise MaintenancePolicyError(
+                "Current branch does not match the approved feature branch"
+            )
+
+        return self._run(
+            ["git", "push", "-u", "origin", safe_branch],
+            cwd=repo,
+        )
+
+    def open_pull_request(
+        self,
+        github_repository: str,
+        head_branch: str,
+        title: str,
+        body: str,
+        approved: bool,
+        base_branch: str = "main",
+    ) -> CommandResult:
+        """Open an approved pull request without merging it."""
+
+        if not approved:
+            raise MaintenancePolicyError(
+                "Explicit approval is required before opening a pull request"
+            )
+
+        safe_head = _validate_feature_branch(head_branch)
+
+        if base_branch not in {"main", "master"}:
+            raise MaintenancePolicyError(
+                "Pull-request base must be main or master"
+            )
+
+        if not title.strip():
+            raise MaintenancePolicyError(
+                "Pull-request title must not be empty"
+            )
+
+        if "/" not in github_repository:
+            raise MaintenancePolicyError(
+                "GitHub repository must use owner/name format"
+            )
+
+        return self._run(
+            [
+                "gh",
+                "pr",
+                "create",
+                "--repo",
+                github_repository,
+                "--base",
+                base_branch,
+                "--head",
+                safe_head,
+                "--title",
+                title.strip(),
+                "--body",
+                body,
+            ]
+        )
+
+    def merge_pull_request(self, *_args: object, **_kwargs: object) -> None:
+        """Block merges; Adrien D. Thomas retains final merge authority."""
+
+        raise MaintenancePolicyError(
+            "Pull-request merging is not permitted through this adapter"
+        )

--- a/tests/garvis/test_github_maintenance.py
+++ b/tests/garvis/test_github_maintenance.py
@@ -1,0 +1,260 @@
+from pathlib import Path
+from typing import List, Optional, Sequence, Tuple
+
+import pytest
+
+from garvis.github_maintenance import (
+    CommandResult,
+    GitHubMaintenanceAdapter,
+    MaintenancePolicyError,
+)
+
+
+class RecordingAdapter(GitHubMaintenanceAdapter):
+    def __init__(self) -> None:
+        super().__init__()
+        self.commands: List[Tuple[Tuple[str, ...], Optional[Path]]] = []
+        self.branch = "feature/test-maintenance"
+
+    def _run(
+        self,
+        command: Sequence[str],
+        cwd: Optional[Path] = None,
+    ) -> CommandResult:
+        recorded = tuple(command)
+        self.commands.append((recorded, cwd))
+
+        if recorded == ("git", "branch", "--show-current"):
+            stdout = self.branch + "\n"
+        elif recorded == ("git", "status", "--short"):
+            stdout = ""
+        elif recorded == ("git", "log", "-1", "--oneline"):
+            stdout = "abc1234 Test commit\n"
+        elif recorded == ("git", "remote", "-v"):
+            stdout = "origin git@github.com:ProCityHub/GARVIS.git\n"
+        else:
+            stdout = "ok\n"
+
+        return CommandResult(
+            command=recorded,
+            returncode=0,
+            stdout=stdout,
+            stderr="",
+        )
+
+
+@pytest.fixture
+def repository(tmp_path: Path) -> Path:
+    repo = tmp_path / "repository"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    return repo
+
+
+def test_repository_inspection_is_read_only(repository: Path) -> None:
+    adapter = RecordingAdapter()
+
+    result = adapter.inspect_repository(repository)
+
+    assert result.branch == "feature/test-maintenance"
+    assert result.latest_commit == "abc1234 Test commit"
+    assert ("git", "status", "--short") in [
+        command for command, _cwd in adapter.commands
+    ]
+    assert not any(
+        command[:2] in {("git", "add"), ("git", "commit")}
+        for command, _cwd in adapter.commands
+    )
+
+
+def test_pull_request_listing_uses_read_only_command() -> None:
+    adapter = RecordingAdapter()
+
+    adapter.list_pull_requests("ProCityHub/GARVIS")
+
+    command = adapter.commands[-1][0]
+    assert command[:3] == ("gh", "pr", "list")
+    assert "create" not in command
+
+
+def test_workflow_listing_uses_read_only_command() -> None:
+    adapter = RecordingAdapter()
+
+    adapter.list_workflow_runs("ProCityHub/GARVIS")
+
+    command = adapter.commands[-1][0]
+    assert command[:3] == ("gh", "run", "list")
+
+
+def test_commit_requires_explicit_approval(repository: Path) -> None:
+    adapter = RecordingAdapter()
+
+    with pytest.raises(
+        MaintenancePolicyError,
+        match="Explicit approval",
+    ):
+        adapter.commit_feature_changes(
+            repository=repository,
+            branch="feature/test-maintenance",
+            relative_paths=["src/garvis/example.py"],
+            message="Test change",
+            approved=False,
+        )
+
+
+def test_commit_stages_only_reviewed_paths(repository: Path) -> None:
+    adapter = RecordingAdapter()
+
+    adapter.commit_feature_changes(
+        repository=repository,
+        branch="feature/test-maintenance",
+        relative_paths=[
+            "src/garvis/example.py",
+            "tests/garvis/test_example.py",
+        ],
+        message="Test reviewed change",
+        approved=True,
+    )
+
+    commands = [command for command, _cwd in adapter.commands]
+
+    assert (
+        "git",
+        "add",
+        "--",
+        "src/garvis/example.py",
+        "tests/garvis/test_example.py",
+    ) in commands
+
+    assert (
+        "git",
+        "commit",
+        "-m",
+        "Test reviewed change",
+    ) in commands
+
+
+@pytest.mark.parametrize(
+    "blocked_path",
+    [
+        ".env",
+        "openai.env",
+        "credentials.json",
+        ".ssh/id_rsa",
+        "../outside.txt",
+        ".git/config",
+    ],
+)
+def test_commit_blocks_secret_or_unsafe_paths(
+    repository: Path,
+    blocked_path: str,
+) -> None:
+    adapter = RecordingAdapter()
+
+    with pytest.raises(MaintenancePolicyError):
+        adapter.commit_feature_changes(
+            repository=repository,
+            branch="feature/test-maintenance",
+            relative_paths=[blocked_path],
+            message="Unsafe change",
+            approved=True,
+        )
+
+
+@pytest.mark.parametrize(
+    "branch",
+    ["main", "master", "production", "prod", "release"],
+)
+def test_push_blocks_protected_branches(
+    repository: Path,
+    branch: str,
+) -> None:
+    adapter = RecordingAdapter()
+    adapter.branch = branch
+
+    with pytest.raises(
+        MaintenancePolicyError,
+        match="Protected branch",
+    ):
+        adapter.push_feature_branch(
+            repository=repository,
+            branch=branch,
+            approved=True,
+        )
+
+
+def test_push_requires_explicit_approval(repository: Path) -> None:
+    adapter = RecordingAdapter()
+
+    with pytest.raises(
+        MaintenancePolicyError,
+        match="Explicit approval",
+    ):
+        adapter.push_feature_branch(
+            repository=repository,
+            branch="feature/test-maintenance",
+            approved=False,
+        )
+
+
+def test_push_feature_branch_never_uses_force(repository: Path) -> None:
+    adapter = RecordingAdapter()
+
+    adapter.push_feature_branch(
+        repository=repository,
+        branch="feature/test-maintenance",
+        approved=True,
+    )
+
+    command = adapter.commands[-1][0]
+    assert command == (
+        "git",
+        "push",
+        "-u",
+        "origin",
+        "feature/test-maintenance",
+    )
+    assert "--force" not in command
+    assert "-f" not in command
+
+
+def test_open_pull_request_requires_approval() -> None:
+    adapter = RecordingAdapter()
+
+    with pytest.raises(
+        MaintenancePolicyError,
+        match="Explicit approval",
+    ):
+        adapter.open_pull_request(
+            github_repository="ProCityHub/GARVIS",
+            head_branch="feature/test-maintenance",
+            title="Test pull request",
+            body="Test body",
+            approved=False,
+        )
+
+
+def test_open_pull_request_does_not_merge() -> None:
+    adapter = RecordingAdapter()
+
+    adapter.open_pull_request(
+        github_repository="ProCityHub/GARVIS",
+        head_branch="feature/test-maintenance",
+        title="Test pull request",
+        body="Test body",
+        approved=True,
+    )
+
+    command = adapter.commands[-1][0]
+    assert command[:3] == ("gh", "pr", "create")
+    assert "merge" not in command
+
+
+def test_merge_is_always_blocked() -> None:
+    adapter = RecordingAdapter()
+
+    with pytest.raises(
+        MaintenancePolicyError,
+        match="merging is not permitted",
+    ):
+        adapter.merge_pull_request(27)


### PR DESCRIPTION
## Summary

Adds a bounded Git and GitHub maintenance adapter for GARVIS.

## Capabilities

- Read-only repository inspection
- Pull-request listing
- GitHub Actions run listing
- Exact-path staging and feature-branch commits
- Non-force feature-branch pushes
- Pull-request creation

## Safety boundaries

- Blocks main, master, production, prod, and release branch pushes
- Blocks force pushes and destructive arguments
- Blocks credential and secret paths
- Removes common credential variables from subprocess environments
- Requires explicit approval for commits, pushes, and pull-request creation
- Does not provide merge, deployment, deletion, billing, account, or secret-management access
- Adrien D. Thomas retains final merge and external-action authority

## Validation

- Targeted adapter tests pass
- Full GARVIS tests pass
- Syntax validation passes
- Diff validation passes
- Credential scan passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added controlled GitHub maintenance capabilities for repository inspection, pull request and workflow viewing, approved feature commits, branch pushes, and pull request creation.
  * Added safeguards against destructive operations, unsafe paths, protected branches, credential exposure, and unauthorized changes.
  * Pull request merging is explicitly unavailable.

* **Tests**
  * Added coverage verifying read-only inspections, approval requirements, safe path handling, protected branch restrictions, and non-forced pushes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->