### PR TITLE
Add deterministic attractor-memory prototype

### DIFF
--- a/docs/ATTRACTOR_MEMORY_EXPERIMENT.md
+++ b/docs/ATTRACTOR_MEMORY_EXPERIMENT.md
@@ -1,0 +1,145 @@
+# GARVIS Attractor-Memory Prototype
+
+Author: Adrien D. Thomas
+
+Status: deterministic software experiment
+
+Scientific boundary: this prototype does not establish consciousness,
+sentience, identity persistence, true AGI, biological equivalence,
+quantum validation, or a physical law.
+
+## Purpose
+
+Build a Hopfield-style associative-memory component that:
+
+1. Stores bipolar patterns in distributed interaction weights.
+2. Accepts complete, partial, or noisy cues.
+3. Iteratively settles toward a stable state.
+4. Reports convergence, recovery accuracy, energy, and failures.
+
+The network weights are the storage mechanism. This must not be described
+as memory existing without storage.
+
+## State representation
+
+Stored patterns contain only -1 and +1.
+
+Recall cues may also contain 0, representing an erased or unknown value.
+
+All patterns must have the same length.
+
+## Weight construction
+
+For stored patterns x_k of dimension n:
+
+W = (1 / n) * sum of outer_product(x_k, x_k)
+
+The weight matrix must be symmetric.
+
+Every diagonal value must be zero.
+
+Recall must use the weight matrix rather than a filename, database key,
+pattern identifier, or lookup index.
+
+## Settling rule
+
+Use deterministic asynchronous neuron updates.
+
+For each neuron:
+
+field = sum(W[i][j] * state[j])
+
+If field is positive, set the neuron to +1.
+If field is negative, set the neuron to -1.
+If field is zero, preserve its current value.
+If both the field and current value are zero, use +1.
+
+One sweep updates every neuron once.
+
+The network converges when one complete sweep produces no changes.
+
+A finite maximum number of sweeps is mandatory.
+
+## Energy
+
+For a fully bipolar state:
+
+E = -0.5 * state_transpose * W * state
+
+Energy should not increase during deterministic asynchronous settling.
+
+This is a software invariant, not evidence of physical energy.
+
+## Required measurements
+
+Each recall result must report:
+
+- final state;
+- converged or not converged;
+- number of sweeps;
+- total state changes;
+- energy trace;
+- exact target match when a target is supplied;
+- Hamming distance when a target is supplied;
+- warnings or failure reason.
+
+## Required tests
+
+The implementation must test:
+
+1. Empty-pattern rejection.
+2. Inconsistent-dimension rejection.
+3. Invalid-value rejection.
+4. Symmetric weights and zero diagonal.
+5. Exact recall from complete stored cues.
+6. Recall from partial cues.
+7. Recall from controlled bit-flip noise.
+8. Deterministic results using the same seed.
+9. Bounded non-convergence handling.
+10. Non-increasing asynchronous energy.
+11. False-attractor reporting.
+12. Capacity and interference with multiple patterns.
+
+Successful, failed, and ambiguous recalls must all remain visible.
+
+## Baselines
+
+The experiment must compare attractor recall against:
+
+1. An explicit nearest-pattern lookup baseline.
+2. A no-memory baseline that fills erased bits deterministically without
+   learned associative settling.
+
+The comparison is descriptive unless a separate experiment is preregistered.
+
+## Engineering boundary
+
+The first implementation will use only the Python standard library.
+
+Proposed module:
+
+src/garvis/attractor_memory.py
+
+Proposed tests:
+
+tests/garvis/test_attractor_memory.py
+
+The memory module must not perform:
+
+- filesystem writes;
+- network access;
+- subprocess execution;
+- Git operations;
+- secret access;
+- model calls;
+- external actions.
+
+## Future GARVIS integration
+
+A later integration may supply attractor output as optional context.
+
+Recalled content must include provenance and confidence and must never be
+treated as unquestioned truth.
+
+Attractor memory remains separate from session history, repository evidence,
+scientific claims, approvals, and external-action authority.

--- a/src/garvis/attractor_memory.py
+++ b/src/garvis/attractor_memory.py
@@ -1,0 +1,313 @@
+"""Deterministic Hopfield-style associative memory.
+
+This module demonstrates distributed pattern storage and bounded recall.
+It does not establish consciousness, identity persistence, or biological memory.
+"""
+
+# Ruff's PEP 604 suggestions require Python 3.10 syntax.
+# GARVIS supports Python 3.9, so Optional and Union remain intentional.
+# ruff: noqa: UP007, UP045
+
+from __future__ import annotations
+
+import random
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Optional, Union
+
+BipolarPattern = tuple[int, ...]
+WeightMatrix = tuple[tuple[float, ...], ...]
+CorruptionAmount = Union[int, float]
+
+
+@dataclass(frozen=True)
+class RecallResult:
+    """Structured result from one bounded recall attempt."""
+
+    initial_state: BipolarPattern
+    final_state: BipolarPattern
+    converged: bool
+    sweeps: int
+    state_changes: int
+    initial_energy: Optional[float]
+    final_energy: float
+    energy_trace: tuple[float, ...]
+    exact_match: Optional[bool]
+    hamming_distance: Optional[int]
+    warnings: tuple[str, ...]
+
+
+class HopfieldMemory:
+    """Small deterministic asynchronous Hopfield network."""
+
+    def __init__(self, patterns: Sequence[Sequence[int]]) -> None:
+        normalized = tuple(self._validate_stored_patterns(patterns))
+        self._patterns: tuple[BipolarPattern, ...] = normalized
+        self.dimension = len(normalized[0])
+        self.weights: WeightMatrix = self._build_weights(normalized)
+
+    @staticmethod
+    def _validate_integer_value(value: object, allowed: tuple[int, ...]) -> int:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ValueError(f"state values must be integers from {allowed}")
+        if value not in allowed:
+            raise ValueError(f"state values must be integers from {allowed}")
+        return value
+
+    @classmethod
+    def _validate_stored_patterns(
+        cls,
+        patterns: Sequence[Sequence[int]],
+    ) -> list[BipolarPattern]:
+        if not patterns:
+            raise ValueError("at least one stored pattern is required")
+
+        normalized: list[BipolarPattern] = []
+        expected_dimension: Optional[int] = None
+
+        for pattern in patterns:
+            values = tuple(cls._validate_integer_value(value, (-1, 1)) for value in pattern)
+
+            if not values:
+                raise ValueError("stored patterns cannot be empty")
+
+            if expected_dimension is None:
+                expected_dimension = len(values)
+            elif len(values) != expected_dimension:
+                raise ValueError("all stored patterns must have the same dimension")
+
+            normalized.append(values)
+
+        return normalized
+
+    def _validate_cue(self, cue: Sequence[int]) -> BipolarPattern:
+        values = tuple(self._validate_integer_value(value, (-1, 0, 1)) for value in cue)
+
+        if len(values) != self.dimension:
+            raise ValueError(
+                f"cue dimension {len(values)} does not match network dimension {self.dimension}"
+            )
+
+        return values
+
+    def _validate_target(self, target: Sequence[int]) -> BipolarPattern:
+        values = tuple(self._validate_integer_value(value, (-1, 1)) for value in target)
+
+        if len(values) != self.dimension:
+            raise ValueError(
+                f"target dimension {len(values)} does not match network dimension {self.dimension}"
+            )
+
+        return values
+
+    @staticmethod
+    def _build_weights(patterns: tuple[BipolarPattern, ...]) -> WeightMatrix:
+        dimension = len(patterns[0])
+        matrix: list[list[float]] = [[0.0 for _ in range(dimension)] for _ in range(dimension)]
+
+        for row in range(dimension):
+            for column in range(dimension):
+                if row == column:
+                    matrix[row][column] = 0.0
+                    continue
+
+                total = sum(pattern[row] * pattern[column] for pattern in patterns)
+                matrix[row][column] = total / dimension
+
+        return tuple(tuple(row) for row in matrix)
+
+    def energy(self, state: Sequence[int]) -> float:
+        """Return the Hopfield energy of a complete bipolar state."""
+
+        values = self._validate_target(state)
+        total = 0.0
+
+        for row in range(self.dimension):
+            for column in range(self.dimension):
+                total += values[row] * self.weights[row][column] * values[column]
+
+        return -0.5 * total
+
+    def recall(
+        self,
+        cue: Sequence[int],
+        *,
+        target: Optional[Sequence[int]] = None,
+        max_sweeps: int = 50,
+    ) -> RecallResult:
+        """Settle a cue using deterministic asynchronous updates."""
+
+        if isinstance(max_sweeps, bool) or not isinstance(max_sweeps, int):
+            raise ValueError("max_sweeps must be a positive integer")
+        if max_sweeps <= 0:
+            raise ValueError("max_sweeps must be a positive integer")
+
+        initial = self._validate_cue(cue)
+        expected = self._validate_target(target) if target is not None else None
+        state = list(initial)
+
+        initial_energy = None
+        if 0 not in state:
+            initial_energy = self.energy(state)
+
+        energy_trace: list[float] = []
+        total_changes = 0
+        converged = False
+        energy_increased = False
+        previous_energy = initial_energy
+        completed_sweeps = 0
+
+        for sweep in range(1, max_sweeps + 1):
+            changes_this_sweep = 0
+
+            for neuron in range(self.dimension):
+                field = sum(
+                    self.weights[neuron][other] * state[other] for other in range(self.dimension)
+                )
+
+                if field > 0:
+                    new_value = 1
+                elif field < 0:
+                    new_value = -1
+                elif state[neuron] in (-1, 1):
+                    new_value = state[neuron]
+                else:
+                    new_value = 1
+
+                if new_value != state[neuron]:
+                    state[neuron] = new_value
+                    changes_this_sweep += 1
+                    total_changes += 1
+
+            completed_sweeps = sweep
+            current_energy = self.energy(state)
+            energy_trace.append(current_energy)
+
+            if previous_energy is not None and current_energy > previous_energy + 1e-12:
+                energy_increased = True
+
+            previous_energy = current_energy
+
+            if changes_this_sweep == 0:
+                converged = True
+                break
+
+        final_state = tuple(state)
+        warnings: list[str] = []
+
+        if not converged:
+            warnings.append("maximum_sweeps_reached_without_convergence")
+
+        if energy_increased:
+            warnings.append("energy_increased_during_asynchronous_settling")
+
+        exact_match: Optional[bool] = None
+        hamming_distance: Optional[int] = None
+
+        if expected is not None:
+            hamming_distance = sum(
+                actual != wanted for actual, wanted in zip(final_state, expected)
+            )
+            exact_match = hamming_distance == 0
+
+            if converged and not exact_match:
+                warnings.append("converged_to_non_target_attractor")
+
+        return RecallResult(
+            initial_state=initial,
+            final_state=final_state,
+            converged=converged,
+            sweeps=completed_sweeps,
+            state_changes=total_changes,
+            initial_energy=initial_energy,
+            final_energy=energy_trace[-1],
+            energy_trace=tuple(energy_trace),
+            exact_match=exact_match,
+            hamming_distance=hamming_distance,
+            warnings=tuple(warnings),
+        )
+
+    def nearest_pattern(self, cue: Sequence[int]) -> BipolarPattern:
+        """Explicit-storage baseline using known-bit Hamming distance."""
+
+        values = self._validate_cue(cue)
+        known_positions = [index for index, value in enumerate(values) if value != 0]
+
+        def distance(pattern: BipolarPattern) -> int:
+            return sum(pattern[index] != values[index] for index in known_positions)
+
+        return min(self._patterns, key=distance)
+
+    def no_memory_baseline(self, cue: Sequence[int]) -> BipolarPattern:
+        """Return the cue with erased values deterministically filled as +1."""
+
+        values = self._validate_cue(cue)
+        return tuple(1 if value == 0 else value for value in values)
+
+
+def _resolve_corruption_count(
+    amount: CorruptionAmount,
+    dimension: int,
+) -> int:
+    if isinstance(amount, bool):
+        raise ValueError("corruption amount must be an integer count or fraction")
+
+    if isinstance(amount, int):
+        count = amount
+    elif isinstance(amount, float):
+        if not 0.0 <= amount <= 1.0:
+            raise ValueError("fractional corruption amount must be between 0 and 1")
+        count = int((dimension * amount) + 0.5)
+    else:
+        raise ValueError("corruption amount must be an integer count or fraction")
+
+    if not 0 <= count <= dimension:
+        raise ValueError("corruption count exceeds pattern dimension")
+
+    return count
+
+
+def flip_bits(
+    pattern: Sequence[int],
+    amount: CorruptionAmount,
+    *,
+    seed: int,
+) -> BipolarPattern:
+    """Return a reproducibly bit-flipped copy of a bipolar pattern."""
+
+    values = tuple(HopfieldMemory._validate_integer_value(value, (-1, 1)) for value in pattern)
+
+    if not values:
+        raise ValueError("pattern cannot be empty")
+
+    count = _resolve_corruption_count(amount, len(values))
+    positions = random.Random(seed).sample(range(len(values)), count)
+    result = list(values)
+
+    for position in positions:
+        result[position] *= -1
+
+    return tuple(result)
+
+
+def erase_bits(
+    pattern: Sequence[int],
+    amount: CorruptionAmount,
+    *,
+    seed: int,
+) -> BipolarPattern:
+    """Return a reproducibly erased copy of a bipolar pattern."""
+
+    values = tuple(HopfieldMemory._validate_integer_value(value, (-1, 1)) for value in pattern)
+
+    if not values:
+        raise ValueError("pattern cannot be empty")
+
+    count = _resolve_corruption_count(amount, len(values))
+    positions = random.Random(seed).sample(range(len(values)), count)
+    result = list(values)
+
+    for position in positions:
+        result[position] = 0
+
+    return tuple(result)

--- a/tests/garvis/test_attractor_memory.py
+++ b/tests/garvis/test_attractor_memory.py
@@ -106,7 +106,7 @@ class TestRecall(unittest.TestCase):
 
         result = memory.recall(cue, target=PATTERN_A)
 
-        self.assertIsNotNone(result.initial_energy)
+        assert result.initial_energy is not None
 
         energies = (result.initial_energy,) + result.energy_trace
 
@@ -129,6 +129,7 @@ class TestRecall(unittest.TestCase):
 
         self.assertTrue(result.converged)
         self.assertFalse(result.exact_match)
+        assert result.hamming_distance is not None
         self.assertGreater(result.hamming_distance, 0)
         self.assertIn(
             "converged_to_non_target_attractor",
@@ -176,6 +177,7 @@ class TestRecall(unittest.TestCase):
 
         self.assertTrue(result.converged)
         self.assertFalse(result.exact_match)
+        assert result.hamming_distance is not None
         self.assertGreater(result.hamming_distance, 0)
         self.assertIn(
             "converged_to_non_target_attractor",

--- a/tests/garvis/test_attractor_memory.py
+++ b/tests/garvis/test_attractor_memory.py
@@ -1,0 +1,250 @@
+"""Tests for the deterministic GARVIS attractor-memory prototype."""
+
+import unittest
+
+from garvis.attractor_memory import (
+    HopfieldMemory,
+    erase_bits,
+    flip_bits,
+)
+
+PATTERN_A = (1, 1, 1, 1, -1, -1, -1, -1)
+PATTERN_B = (1, 1, -1, -1, 1, 1, -1, -1)
+PATTERN_C = (1, -1, 1, -1, 1, -1, 1, -1)
+
+ORTHOGONAL_PATTERNS = (
+    PATTERN_A,
+    PATTERN_B,
+    PATTERN_C,
+)
+
+
+class TestInputValidation(unittest.TestCase):
+    def test_rejects_empty_pattern_collection(self):
+        with self.assertRaisesRegex(ValueError, "at least one"):
+            HopfieldMemory([])
+
+    def test_rejects_empty_stored_pattern(self):
+        with self.assertRaisesRegex(ValueError, "cannot be empty"):
+            HopfieldMemory([()])
+
+    def test_rejects_inconsistent_dimensions(self):
+        with self.assertRaisesRegex(ValueError, "same dimension"):
+            HopfieldMemory([(1, -1), (1, -1, 1)])
+
+    def test_rejects_invalid_stored_value(self):
+        with self.assertRaisesRegex(ValueError, "state values"):
+            HopfieldMemory([(1, 0, -1)])
+
+    def test_rejects_invalid_cue_dimension(self):
+        memory = HopfieldMemory([PATTERN_A])
+
+        with self.assertRaisesRegex(ValueError, "cue dimension"):
+            memory.recall((1, -1))
+
+    def test_rejects_nonpositive_sweep_limit(self):
+        memory = HopfieldMemory([PATTERN_A])
+
+        with self.assertRaisesRegex(ValueError, "positive integer"):
+            memory.recall(PATTERN_A, max_sweeps=0)
+
+
+class TestWeightMatrix(unittest.TestCase):
+    def test_weights_are_symmetric_with_zero_diagonal(self):
+        memory = HopfieldMemory(ORTHOGONAL_PATTERNS)
+
+        for row in range(memory.dimension):
+            self.assertEqual(memory.weights[row][row], 0.0)
+
+            for column in range(memory.dimension):
+                self.assertAlmostEqual(
+                    memory.weights[row][column],
+                    memory.weights[column][row],
+                )
+
+
+class TestRecall(unittest.TestCase):
+    def test_exact_recall_of_all_stored_patterns(self):
+        memory = HopfieldMemory(ORTHOGONAL_PATTERNS)
+
+        for pattern in ORTHOGONAL_PATTERNS:
+            with self.subTest(pattern=pattern):
+                result = memory.recall(pattern, target=pattern)
+
+                self.assertTrue(result.converged)
+                self.assertTrue(result.exact_match)
+                self.assertEqual(result.hamming_distance, 0)
+                self.assertEqual(result.final_state, pattern)
+                self.assertEqual(result.warnings, ())
+
+    def test_partial_cue_recall(self):
+        memory = HopfieldMemory([PATTERN_A])
+        cue = erase_bits(PATTERN_A, 3, seed=11)
+
+        result = memory.recall(cue, target=PATTERN_A)
+
+        self.assertIn(0, cue)
+        self.assertTrue(result.converged)
+        self.assertTrue(result.exact_match)
+        self.assertEqual(result.final_state, PATTERN_A)
+        self.assertNotIn(0, result.final_state)
+
+    def test_noisy_cue_recall(self):
+        memory = HopfieldMemory([PATTERN_A])
+        cue = flip_bits(PATTERN_A, 3, seed=7)
+
+        result = memory.recall(cue, target=PATTERN_A)
+
+        self.assertNotEqual(cue, PATTERN_A)
+        self.assertTrue(result.converged)
+        self.assertTrue(result.exact_match)
+        self.assertEqual(result.final_state, PATTERN_A)
+
+    def test_energy_does_not_increase(self):
+        memory = HopfieldMemory([PATTERN_A])
+        cue = flip_bits(PATTERN_A, 3, seed=4)
+
+        result = memory.recall(cue, target=PATTERN_A)
+
+        self.assertIsNotNone(result.initial_energy)
+
+        energies = (result.initial_energy,) + result.energy_trace
+
+        for earlier, later in zip(energies, energies[1:]):
+            self.assertLessEqual(later, earlier + 1e-12)
+
+        self.assertNotIn(
+            "energy_increased_during_asynchronous_settling",
+            result.warnings,
+        )
+
+    def test_false_attractor_is_reported(self):
+        memory = HopfieldMemory([PATTERN_A])
+        inverted_pattern = tuple(-value for value in PATTERN_A)
+
+        result = memory.recall(
+            inverted_pattern,
+            target=PATTERN_A,
+        )
+
+        self.assertTrue(result.converged)
+        self.assertFalse(result.exact_match)
+        self.assertGreater(result.hamming_distance, 0)
+        self.assertIn(
+            "converged_to_non_target_attractor",
+            result.warnings,
+        )
+
+    def test_nonconvergence_is_bounded_and_reported(self):
+        memory = HopfieldMemory([(1, 1)])
+
+        memory.weights = (
+            (0.0, -1.0),
+            (1.0, 0.0),
+        )
+
+        result = memory.recall(
+            (-1, -1),
+            max_sweeps=4,
+        )
+
+        self.assertFalse(result.converged)
+        self.assertEqual(result.sweeps, 4)
+        self.assertIn(
+            "maximum_sweeps_reached_without_convergence",
+            result.warnings,
+        )
+
+    def test_multiple_pattern_interference_remains_visible(self):
+        memory = HopfieldMemory(ORTHOGONAL_PATTERNS)
+
+        noisy_cue = (
+            1,
+            1,
+            1,
+            1,
+            -1,
+            -1,
+            1,
+            -1,
+        )
+
+        result = memory.recall(
+            noisy_cue,
+            target=PATTERN_A,
+        )
+
+        self.assertTrue(result.converged)
+        self.assertFalse(result.exact_match)
+        self.assertGreater(result.hamming_distance, 0)
+        self.assertIn(
+            "converged_to_non_target_attractor",
+            result.warnings,
+        )
+
+
+class TestCorruptionUtilities(unittest.TestCase):
+    def test_flip_bits_is_reproducible(self):
+        first = flip_bits(PATTERN_A, 2, seed=123)
+        second = flip_bits(PATTERN_A, 2, seed=123)
+
+        self.assertEqual(first, second)
+
+        changed = sum(original != corrupted for original, corrupted in zip(PATTERN_A, first))
+
+        self.assertEqual(changed, 2)
+        self.assertEqual(PATTERN_A, (1, 1, 1, 1, -1, -1, -1, -1))
+
+    def test_erase_bits_is_reproducible(self):
+        first = erase_bits(PATTERN_A, 3, seed=456)
+        second = erase_bits(PATTERN_A, 3, seed=456)
+
+        self.assertEqual(first, second)
+        self.assertEqual(first.count(0), 3)
+        self.assertEqual(PATTERN_A, (1, 1, 1, 1, -1, -1, -1, -1))
+
+
+class TestBaselines(unittest.TestCase):
+    def test_nearest_pattern_baseline(self):
+        memory = HopfieldMemory(ORTHOGONAL_PATTERNS)
+
+        cue = (
+            1,
+            1,
+            0,
+            0,
+            -1,
+            -1,
+            -1,
+            -1,
+        )
+
+        self.assertEqual(
+            memory.nearest_pattern(cue),
+            PATTERN_A,
+        )
+
+    def test_no_memory_baseline(self):
+        memory = HopfieldMemory([PATTERN_A])
+
+        cue = (
+            1,
+            0,
+            -1,
+            0,
+            1,
+            -1,
+            0,
+            -1,
+        )
+
+        result = memory.no_memory_baseline(cue)
+
+        self.assertEqual(
+            result,
+            (1, 1, -1, 1, 1, -1, 1, -1),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/garvis/test_github_maintenance.py
+++ b/tests/garvis/test_github_maintenance.py
@@ -1,5 +1,6 @@
+from collections.abc import Sequence
 from pathlib import Path
-from typing import List, Optional, Sequence, Tuple
+from typing import Optional
 
 import pytest
 
@@ -13,7 +14,7 @@ from garvis.github_maintenance import (
 class RecordingAdapter(GitHubMaintenanceAdapter):
     def __init__(self) -> None:
         super().__init__()
-        self.commands: List[Tuple[Tuple[str, ...], Optional[Path]]] = []
+        self.commands: list[tuple[tuple[str, ...], Optional[Path]]] = []
         self.branch = "feature/test-maintenance"
 
     def _run(
@@ -58,12 +59,9 @@ def test_repository_inspection_is_read_only(repository: Path) -> None:
 
     assert result.branch == "feature/test-maintenance"
     assert result.latest_commit == "abc1234 Test commit"
-    assert ("git", "status", "--short") in [
-        command for command, _cwd in adapter.commands
-    ]
+    assert ("git", "status", "--short") in [command for command, _cwd in adapter.commands]
     assert not any(
-        command[:2] in {("git", "add"), ("git", "commit")}
-        for command, _cwd in adapter.commands
+        command[:2] in {("git", "add"), ("git", "commit")} for command, _cwd in adapter.commands
     )
 
 


### PR DESCRIPTION
## Summary

Adds a bounded Hopfield-style associative-memory prototype for GARVIS.

## Included

- deterministic bipolar pattern storage and bounded asynchronous recall
- convergence, energy-trace, target-match, and failure reporting
- reproducible bit-flip and erasure utilities
- nearest-pattern and no-memory baselines
- engineering contract and explicit scientific non-claims

## Local validation

- Ruff passed
- Python syntax passed
- 18 targeted attractor-memory tests passed
- 71 full GARVIS tests passed
- whitespace checks passed

## Boundaries

The module performs no network access, model calls, subprocesses, Git operations, secret access, or external actions. Passing tests demonstrate tested software behavior only; they do not establish consciousness, sentience, identity persistence, true AGI, biological equivalence, quantum behavior, or a physical law.

Merge remains under Adrien D. Thomas’s manual authority.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deterministic associative memory that recalls stored bipolar patterns from incomplete or corrupted cues.
  * Added recall results with convergence status, energy tracking, state changes, accuracy metrics, and warnings.
  * Added nearest-pattern and no-memory comparison baselines.
  * Added reproducible bit-flipping and bit-erasure utilities.

* **Documentation**
  * Added a prototype specification covering behavior, measurements, validation, testing, and integration guidelines.

* **Tests**
  * Added comprehensive coverage for validation, recall, convergence, interference, baselines, and reproducible corruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->