### PR TITLE
Harden GARVIS CI job permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,11 +62,15 @@ jobs:
 
   garvis-tests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       OPENAI_API_KEY: fake-for-tests
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup uv
         uses: astral-sh/setup-uv@v5
         with:
@@ -78,9 +82,13 @@ jobs:
 
   garvis-package:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup uv
         uses: astral-sh/setup-uv@v5
       - name: Build GARVIS wheel


### PR DESCRIPTION
## Summary

Applies the security hardening requested during review of PR #30.

## Changes

- Adds `permissions: contents: read` to the `garvis-tests` job.
- Adds `permissions: contents: read` to the `garvis-package` job.
- Sets `persist-credentials: false` for both checkout steps.

## Validation

- Workflow security structure check passed.
- 72 GARVIS tests and 3 subtests passed.
- Whitespace check passed.

Only `.github/workflows/tests.yml` is changed. No merge is authorized.