### PR TITLE
Add Lattice psychology equilibrium kernel

### DIFF
--- a/src/garvis/psychology/__init__.py
+++ b/src/garvis/psychology/__init__.py
@@ -1,0 +1,23 @@
+"""GARVIS Psychology Kernel."""
+
+from .equilibrium import (
+    FULL_ACTIVATION,
+    SIX_WALL_COHERENCE,
+    UNIFIED_SCALE,
+    EquilibriumResult,
+    evaluate_equilibrium,
+    geometric_equilibrium,
+    psychological_coherence,
+    unified_center,
+)
+
+__all__ = [
+    "FULL_ACTIVATION",
+    "SIX_WALL_COHERENCE",
+    "UNIFIED_SCALE",
+    "EquilibriumResult",
+    "evaluate_equilibrium",
+    "geometric_equilibrium",
+    "psychological_coherence",
+    "unified_center",
+]

--- a/src/garvis/psychology/equilibrium.py
+++ b/src/garvis/psychology/equilibrium.py
@@ -1,0 +1,115 @@
+"""Lattice-Psychology equilibrium mathematics by Adrien D. Thomas."""
+
+from dataclasses import dataclass
+from math import prod
+from typing import Mapping
+
+FULL_ACTIVATION = 1.0
+SIX_WALL_COHERENCE = 0.6
+UNIFIED_SCALE = 1.6
+
+
+def unit(name: str, value: float) -> float:
+    value = float(value)
+    if not 0.0 <= value <= 1.0:
+        raise ValueError(f"{name} must be between 0 and 1")
+    return value
+
+
+def unified_center(activation: float, wall_coherence: float) -> float:
+    """Preserve 1.0 + 0.6 = 1.6, then normalize 1.6 to one full unit."""
+    activation = unit("activation", activation)
+    wall_coherence = unit("wall_coherence", wall_coherence)
+    return min((activation + wall_coherence) / UNIFIED_SCALE, 1.0)
+
+
+def psychological_coherence(tensions: Mapping[str, float]) -> tuple[float, str | None]:
+    """Convert normalized unresolved tensions into coherence."""
+    if not tensions:
+        return 1.0, None
+
+    checked = {name: unit(name, value) for name, value in tensions.items()}
+    limiting = max(checked, key=checked.get)
+    disequilibrium = sum(checked.values()) / len(checked)
+    return 1.0 - disequilibrium, limiting
+
+
+def geometric_equilibrium(dimensions: Mapping[str, float]) -> float:
+    """Integrate required dimensions without letting one strength hide a failure."""
+    if not dimensions:
+        return 1.0
+
+    values = [unit(name, value) for name, value in dimensions.items()]
+    return prod(values) ** (1.0 / len(values))
+
+
+@dataclass(frozen=True)
+class EquilibriumResult:
+    raw_union: float
+    normalized_center: float
+    psychological_coherence: float
+    integrated_equilibrium: float
+    equilibrium_error: float
+    limiting_dimension: str | None
+    corner_bits: tuple[int, int, int]
+    corner_index: int
+    equilibrium_reached: bool
+    proposal_eligible: bool
+    human_approval_required: bool
+
+
+def evaluate_equilibrium(
+    *,
+    activation: float,
+    wall_coherence: float,
+    evidence: float,
+    action_readiness: float,
+    context_stability: float,
+    tensions: Mapping[str, float],
+    constraints_passed: bool,
+    external_action: bool,
+    threshold: float = 0.95,
+) -> EquilibriumResult:
+    activation = unit("activation", activation)
+    wall_coherence = unit("wall_coherence", wall_coherence)
+    evidence = unit("evidence", evidence)
+    action_readiness = unit("action_readiness", action_readiness)
+    context_stability = unit("context_stability", context_stability)
+    threshold = unit("threshold", threshold)
+
+    center = unified_center(activation, wall_coherence)
+    psyche, limiting = psychological_coherence(tensions)
+
+    integrated = geometric_equilibrium(
+        {
+            "center": center,
+            "psychology": psyche,
+            "evidence": evidence,
+            "action": action_readiness,
+            "context": context_stability,
+        }
+    )
+
+    corner_bits = (
+        int(evidence >= threshold),
+        int(action_readiness >= threshold),
+        int(context_stability >= threshold),
+    )
+    corner_index = corner_bits[0] * 4 + corner_bits[1] * 2 + corner_bits[2]
+
+    reached = bool(constraints_passed and integrated >= threshold)
+    eligible = bool(reached and corner_bits == (1, 1, 1))
+
+    return EquilibriumResult(
+        raw_union=activation + wall_coherence,
+        normalized_center=center,
+        psychological_coherence=psyche,
+        integrated_equilibrium=integrated,
+        equilibrium_error=1.0 - integrated,
+        limiting_dimension=limiting,
+        corner_bits=corner_bits,
+        corner_index=corner_index,
+        equilibrium_reached=reached,
+        proposal_eligible=eligible,
+        human_approval_required=bool(external_action),
+    )

--- a/src/garvis/psychology/equilibrium.py
+++ b/src/garvis/psychology/equilibrium.py
@@ -1,5 +1,6 @@
 """Lattice-Psychology equilibrium mathematics by Adrien D. Thomas."""
 
+from __future__ import annotations
 from dataclasses import dataclass
 from math import prod
 from typing import Mapping

--- a/tests/garvis/test_psychology_equilibrium.py
+++ b/tests/garvis/test_psychology_equilibrium.py
@@ -1,0 +1,69 @@
+import pytest
+
+from garvis.psychology import evaluate_equilibrium, unified_center
+
+
+def test_one_plus_point_six_normalization() -> None:
+    assert 1.0 + 0.6 == pytest.approx(1.6)
+    assert unified_center(1.0, 0.6) == pytest.approx(1.0)
+
+
+def test_complete_equilibrium_reaches_corner_seven() -> None:
+    result = evaluate_equilibrium(
+        activation=1.0,
+        wall_coherence=0.6,
+        evidence=1.0,
+        action_readiness=1.0,
+        context_stability=1.0,
+        tensions={
+            "contradiction": 0.0,
+            "uncertainty": 0.0,
+            "memory_conflict": 0.0,
+            "self_model_error": 0.0,
+            "relational_risk": 0.0,
+        },
+        constraints_passed=True,
+        external_action=True,
+    )
+
+    assert result.raw_union == pytest.approx(1.6)
+    assert result.normalized_center == pytest.approx(1.0)
+    assert result.integrated_equilibrium == pytest.approx(1.0)
+    assert result.corner_bits == (1, 1, 1)
+    assert result.corner_index == 7
+    assert result.equilibrium_reached is True
+    assert result.proposal_eligible is True
+    assert result.human_approval_required is True
+
+
+def test_contradiction_blocks_equilibrium() -> None:
+    result = evaluate_equilibrium(
+        activation=1.0,
+        wall_coherence=0.6,
+        evidence=1.0,
+        action_readiness=1.0,
+        context_stability=1.0,
+        tensions={"contradiction": 1.0, "uncertainty": 0.8},
+        constraints_passed=True,
+        external_action=False,
+    )
+
+    assert result.limiting_dimension == "contradiction"
+    assert result.equilibrium_reached is False
+    assert result.proposal_eligible is False
+
+
+def test_failed_constraint_blocks_proposal() -> None:
+    result = evaluate_equilibrium(
+        activation=1.0,
+        wall_coherence=0.6,
+        evidence=1.0,
+        action_readiness=1.0,
+        context_stability=1.0,
+        tensions={},
+        constraints_passed=False,
+        external_action=False,
+    )
+
+    assert result.integrated_equilibrium == pytest.approx(1.0)
+    assert result.equilibrium_reached is False


### PR DESCRIPTION
Authored under the direction of Adrien D. Thomas, operating as ProCityHub.

Adds a deterministic GARVIS Psychology Kernel equilibrium component.

The implementation:
- preserves 1.0 + 0.6 = 1.6
- normalizes the canonical 1.6 union into one unified-center unit
- calculates psychological coherence from unresolved tensions
- integrates center, evidence, action readiness, context stability, and psychology
- maps evidence, action, and context into the eight cube corners
- preserves human approval for external action

Boundaries:
- engineering model only
- no consciousness, sentience, AGI, biological-equivalence, clinical, physical-singularity, or universal-theory claim
- no network connector or external execution capability

Local tests: 4 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added equilibrium evaluation for activation, coherence, evidence, readiness, stability, tensions, and constraints.
  * Added integrated equilibrium scoring with normalized results, limiting dimensions, threshold indicators, and eligibility status.
  * Added human-approval indicators for actions requiring external execution.
  * Exposed psychology equilibrium tools through the package interface.

* **Tests**
  * Added coverage for normalization, complete equilibrium, contradictions, and failed constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->