### PR TITLE
Connect evidence envelopes to psychology kernel

### DIFF
--- a/src/garvis/psychology/__init__.py
+++ b/src/garvis/psychology/__init__.py
@@ -10,12 +10,24 @@ from .equilibrium import (
     psychological_coherence,
     unified_center,
 )
+from .evidence_adapter import (
+    ROUTING_WEIGHTS,
+    EvidenceAssessment,
+    EvidenceSignal,
+    EvidenceSignalKind,
+    adapt_evidence_envelope,
+)
 
 __all__ = [
     "FULL_ACTIVATION",
     "SIX_WALL_COHERENCE",
     "UNIFIED_SCALE",
     "EquilibriumResult",
+    "EvidenceAssessment",
+    "EvidenceSignal",
+    "EvidenceSignalKind",
+    "ROUTING_WEIGHTS",
+    "adapt_evidence_envelope",
     "evaluate_equilibrium",
     "geometric_equilibrium",
     "psychological_coherence",

--- a/src/garvis/psychology/evidence_adapter.py
+++ b/src/garvis/psychology/evidence_adapter.py
@@ -1,0 +1,272 @@
+"""Read-only evidence adapter for the GARVIS Psychology Kernel.
+
+This module converts an immutable GARVIS EvidenceEnvelope into deterministic,
+provenance-linked psychological evidence signals.
+
+The resulting evidence-sufficiency score is an internal routing measurement.
+It is not a scientific probability, truth guarantee, consciousness measure,
+clinical assessment, or authorization for outside-world action.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Tuple
+
+from garvis.evidence_envelope import EvidenceEnvelope
+
+
+class EvidenceSignalKind(str, Enum):
+    """Epistemic source class used by the Psychology Kernel."""
+
+    OBSERVED = "observed"
+    MEASURED = "measured"
+    CLAIMED = "claimed"
+    INFERRED = "inferred"
+    SYMBOLIC = "symbolic"
+    SPECULATIVE = "speculative"
+    UNKNOWN = "unknown"
+
+
+ROUTING_WEIGHTS = {
+    EvidenceSignalKind.OBSERVED: 1.00,
+    EvidenceSignalKind.MEASURED: 1.00,
+    EvidenceSignalKind.CLAIMED: 0.70,
+    EvidenceSignalKind.INFERRED: 0.50,
+    EvidenceSignalKind.SYMBOLIC: 0.25,
+    EvidenceSignalKind.SPECULATIVE: 0.10,
+    EvidenceSignalKind.UNKNOWN: 0.00,
+}
+
+
+def _plain(value: Any) -> Any:
+    """Convert immutable envelope containers into deterministic JSON values."""
+
+    if isinstance(value, Mapping):
+        return {
+            str(key): _plain(item)
+            for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
+        }
+
+    if isinstance(value, (tuple, list)):
+        return [_plain(item) for item in value]
+
+    if isinstance(value, (set, frozenset)):
+        converted = [_plain(item) for item in value]
+        return sorted(
+            converted,
+            key=lambda item: json.dumps(
+                item,
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
+        )
+
+    return value
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(
+        _plain(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+
+
+def _sha256(value: Any) -> str:
+    return hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def _summary(value: Any, limit: int = 240) -> str:
+    encoded = _canonical_json(value)
+
+    if len(encoded) <= limit:
+        return encoded
+
+    return encoded[: limit - 3] + "..."
+
+
+@dataclass(frozen=True)
+class EvidenceSignal:
+    """One immutable evidence item routed into the Psychology Kernel."""
+
+    signal_id: str
+    source_path: str
+    kind: EvidenceSignalKind
+    routing_weight: float
+    content_sha256: str
+    provenance_hash: str
+    summary: str
+    external_action_allowed: bool = False
+
+
+@dataclass(frozen=True)
+class EvidenceAssessment:
+    """Deterministic aggregate assessment produced from an EvidenceEnvelope."""
+
+    signals: Tuple[EvidenceSignal, ...]
+    evidence_sufficiency: float
+    evidence_error: float
+    unknown_fraction: float
+    speculative_fraction: float
+    observed_count: int
+    measured_count: int
+    claimed_count: int
+    inferred_count: int
+    symbolic_count: int
+    speculative_count: int
+    unknown_count: int
+    external_action_allowed: bool
+    claim_boundary: str
+
+    def equilibrium_tensions(self) -> dict[str, float]:
+        """Return bounded tensions accepted by the equilibrium kernel."""
+
+        return {
+            "evidence_error": self.evidence_error,
+            "uncertainty": self.unknown_fraction,
+            "speculation_pressure": self.speculative_fraction,
+        }
+
+
+_BUCKETS = (
+    (
+        "immutable_source_evidence",
+        EvidenceSignalKind.OBSERVED,
+    ),
+    (
+        "hypercube_cycle_data",
+        EvidenceSignalKind.OBSERVED,
+    ),
+    (
+        "deterministic_agi_measurements",
+        EvidenceSignalKind.MEASURED,
+    ),
+    (
+        "scientific_claims",
+        EvidenceSignalKind.CLAIMED,
+    ),
+    (
+        "garvis_evidence_summary",
+        EvidenceSignalKind.INFERRED,
+    ),
+    (
+        "engineering_inference",
+        EvidenceSignalKind.INFERRED,
+    ),
+    (
+        "symbolic_interpretation",
+        EvidenceSignalKind.SYMBOLIC,
+    ),
+    (
+        "unsupported_speculation",
+        EvidenceSignalKind.SPECULATIVE,
+    ),
+    (
+        "unknowns",
+        EvidenceSignalKind.UNKNOWN,
+    ),
+)
+
+
+def _iter_bucket_items(value: Any) -> list[tuple[str, Any]]:
+    if value is None:
+        return []
+
+    if isinstance(value, Mapping):
+        return [
+            (str(key), item)
+            for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
+        ]
+
+    return [("value", value)]
+
+
+def adapt_evidence_envelope(
+    envelope: EvidenceEnvelope,
+) -> EvidenceAssessment:
+    """Convert one immutable evidence envelope into psychological signals."""
+
+    signals: list[EvidenceSignal] = []
+    provenance = dict(envelope.source_provenance_hashes)
+
+    for field_name, kind in _BUCKETS:
+        bucket_value = getattr(envelope, field_name)
+
+        for key, value in _iter_bucket_items(bucket_value):
+            source_path = f"{field_name}.{key}"
+            content_hash = _sha256(value)
+
+            provenance_hash = str(
+                provenance.get(
+                    key,
+                    provenance.get(source_path, content_hash),
+                )
+            )
+
+            signals.append(
+                EvidenceSignal(
+                    signal_id=_sha256(
+                        {
+                            "source_path": source_path,
+                            "kind": kind.value,
+                            "content_sha256": content_hash,
+                        }
+                    ),
+                    source_path=source_path,
+                    kind=kind,
+                    routing_weight=ROUTING_WEIGHTS[kind],
+                    content_sha256=content_hash,
+                    provenance_hash=provenance_hash,
+                    summary=_summary(value),
+                    external_action_allowed=False,
+                )
+            )
+
+    total = len(signals)
+
+    counts = {
+        kind: sum(signal.kind is kind for signal in signals)
+        for kind in EvidenceSignalKind
+    }
+
+    if total == 0:
+        evidence_sufficiency = 0.0
+        unknown_fraction = 1.0
+        speculative_fraction = 0.0
+    else:
+        evidence_sufficiency = (
+            sum(signal.routing_weight for signal in signals) / total
+        )
+        unknown_fraction = counts[EvidenceSignalKind.UNKNOWN] / total
+        speculative_fraction = (
+            counts[EvidenceSignalKind.SPECULATIVE] / total
+        )
+
+    evidence_error = 1.0 - evidence_sufficiency
+
+    return EvidenceAssessment(
+        signals=tuple(signals),
+        evidence_sufficiency=evidence_sufficiency,
+        evidence_error=evidence_error,
+        unknown_fraction=unknown_fraction,
+        speculative_fraction=speculative_fraction,
+        observed_count=counts[EvidenceSignalKind.OBSERVED],
+        measured_count=counts[EvidenceSignalKind.MEASURED],
+        claimed_count=counts[EvidenceSignalKind.CLAIMED],
+        inferred_count=counts[EvidenceSignalKind.INFERRED],
+        symbolic_count=counts[EvidenceSignalKind.SYMBOLIC],
+        speculative_count=counts[EvidenceSignalKind.SPECULATIVE],
+        unknown_count=counts[EvidenceSignalKind.UNKNOWN],
+        external_action_allowed=False,
+        claim_boundary=(
+            "Internal evidence-routing measurement only. "
+            "No truth guarantee, scientific confirmation, clinical assessment, "
+            "consciousness claim, AGI claim, or external-action authority."
+        ),
+    )

--- a/tests/garvis/test_psychology_evidence_adapter.py
+++ b/tests/garvis/test_psychology_evidence_adapter.py
@@ -1,0 +1,146 @@
+import pytest
+
+from garvis.evidence_envelope import build_evidence_envelope
+from garvis.psychology import (
+    EvidenceSignalKind,
+    adapt_evidence_envelope,
+    evaluate_equilibrium,
+)
+
+
+def test_observed_evidence_receives_full_routing_weight() -> None:
+    envelope = build_evidence_envelope(
+        immutable_source_evidence={
+            "result": {
+                "auc_phi": 0.871258,
+                "auc_flat": 0.861944,
+                "delta": 0.009314,
+            }
+        },
+        source_provenance_hashes={
+            "result": "recorded-result-hash",
+        },
+    )
+
+    assessment = adapt_evidence_envelope(envelope)
+
+    assert len(assessment.signals) == 1
+    assert assessment.observed_count == 1
+    assert assessment.evidence_sufficiency == pytest.approx(1.0)
+    assert assessment.evidence_error == pytest.approx(0.0)
+    assert assessment.external_action_allowed is False
+
+    signal = assessment.signals[0]
+
+    assert signal.kind is EvidenceSignalKind.OBSERVED
+    assert signal.routing_weight == pytest.approx(1.0)
+    assert signal.provenance_hash == "recorded-result-hash"
+    assert signal.external_action_allowed is False
+
+
+def test_adapter_separates_inference_symbolism_and_speculation() -> None:
+    envelope = build_evidence_envelope(
+        immutable_source_evidence={"measured": 1},
+        engineering_inference={"interpretation": "possible mechanism"},
+        symbolic_interpretation={"symbol": "0.0 center"},
+        unsupported_speculation={"idea": "unverified extension"},
+        unknowns={"missing": "independent replication"},
+    )
+
+    assessment = adapt_evidence_envelope(envelope)
+
+    assert assessment.observed_count == 1
+    assert assessment.inferred_count == 1
+    assert assessment.symbolic_count == 1
+    assert assessment.speculative_count == 1
+    assert assessment.unknown_count == 1
+
+    expected = (1.0 + 0.5 + 0.25 + 0.1 + 0.0) / 5
+
+    assert assessment.evidence_sufficiency == pytest.approx(expected)
+    assert assessment.evidence_error == pytest.approx(1.0 - expected)
+    assert assessment.unknown_fraction == pytest.approx(0.2)
+    assert assessment.speculative_fraction == pytest.approx(0.2)
+
+
+def test_adapter_output_is_deterministic() -> None:
+    first = build_evidence_envelope(
+        immutable_source_evidence={
+            "b": {"value": 2},
+            "a": {"value": 1},
+        }
+    )
+
+    second = build_evidence_envelope(
+        immutable_source_evidence={
+            "a": {"value": 1},
+            "b": {"value": 2},
+        }
+    )
+
+    first_assessment = adapt_evidence_envelope(first)
+    second_assessment = adapt_evidence_envelope(second)
+
+    assert first_assessment == second_assessment
+    assert [
+        signal.signal_id
+        for signal in first_assessment.signals
+    ] == [
+        signal.signal_id
+        for signal in second_assessment.signals
+    ]
+
+
+def test_empty_envelope_fails_closed() -> None:
+    envelope = build_evidence_envelope(
+        immutable_source_evidence={}
+    )
+
+    assessment = adapt_evidence_envelope(envelope)
+
+    assert assessment.signals == ()
+    assert assessment.evidence_sufficiency == pytest.approx(0.0)
+    assert assessment.evidence_error == pytest.approx(1.0)
+    assert assessment.unknown_fraction == pytest.approx(1.0)
+    assert assessment.external_action_allowed is False
+
+
+def test_uncertain_evidence_reduces_equilibrium() -> None:
+    envelope = build_evidence_envelope(
+        immutable_source_evidence={},
+        unsupported_speculation={"proposal": "unverified"},
+        unknowns={"replication": "missing"},
+    )
+
+    assessment = adapt_evidence_envelope(envelope)
+
+    result = evaluate_equilibrium(
+        activation=1.0,
+        wall_coherence=0.6,
+        evidence=assessment.evidence_sufficiency,
+        action_readiness=1.0,
+        context_stability=1.0,
+        tensions=assessment.equilibrium_tensions(),
+        constraints_passed=True,
+        external_action=False,
+    )
+
+    assert result.integrated_equilibrium < 0.95
+    assert result.equilibrium_reached is False
+    assert result.proposal_eligible is False
+
+
+def test_adapter_does_not_mutate_the_source_envelope() -> None:
+    envelope = build_evidence_envelope(
+        immutable_source_evidence={
+            "result": {"verdict": "NOT_SUPPORTED"}
+        }
+    )
+
+    before = dict(envelope.immutable_source_evidence)
+
+    adapt_evidence_envelope(envelope)
+
+    after = dict(envelope.immutable_source_evidence)
+
+    assert before == after


### PR DESCRIPTION
Authored under the direction of Adrien D. Thomas, operating as ProCityHub.

Adds a deterministic read-only adapter between GARVIS evidence envelopes and the Psychology Kernel.

It preserves provenance, separates observed evidence from inference, symbolism, speculation, and unknowns, calculates bounded evidence sufficiency, converts uncertainty into equilibrium tensions, and grants no external-action authority.

No consciousness, sentience, AGI, clinical, biological-equivalence, network, shell, connector, or execution claim.