### PR TITLE
Add local lattice cognitive cycle CLI

### DIFF
--- a/src/agents/run.py
+++ b/src/agents/run.py
@@ -644,7 +644,7 @@ class AgentRunner:
         conversation_id = kwargs.get("conversation_id")
         session = kwargs.get("session")
 
-        return asyncio.get_event_loop().run_until_complete(
+        return asyncio.run(
             self.run(
                 starting_agent,
                 input,

--- a/src/garvis/cli.py
+++ b/src/garvis/cli.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import json
 import os
 import sys
 from pathlib import Path
 from typing import Optional, Sequence
 
 from .assistant import DEFAULT_MODEL, GarvisAssistant, GarvisResponseError
+from .lattice_cycle_cli import run_lattice_cycle_file
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -44,7 +46,63 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Disable persistent conversation memory for this run.",
     )
+    parser.add_argument(
+        "--lattice-cycle",
+        type=Path,
+        default=None,
+        metavar="JSON_PATH",
+        help=(
+            "Run the local deterministic lattice cognitive cycle "
+            "from an explicit JSON evidence file."
+        ),
+    )
+    parser.add_argument(
+        "--cycle",
+        type=int,
+        default=0,
+        help="Non-negative heartbeat cycle number. Default: %(default)s.",
+    )
+    parser.add_argument(
+        "--external-action",
+        action="store_true",
+        help=(
+            "Mark the evaluated proposal as external. This requests "
+            "human review and never performs the action."
+        ),
+    )
     return parser
+
+
+def _run_local_lattice_cycle(args: argparse.Namespace) -> int:
+    if args.prompt or args.interactive:
+        print(
+            "GARVIS lattice-cycle error: --lattice-cycle cannot be "
+            "combined with a conversation prompt or --interactive.",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        summary = run_lattice_cycle_file(
+            path=args.lattice_cycle,
+            cycle=args.cycle,
+            external_action=args.external_action,
+        )
+    except ValueError as exc:
+        print(
+            f"GARVIS lattice-cycle error: {exc}",
+            file=sys.stderr,
+        )
+        return 2
+
+    print(
+        json.dumps(
+            summary,
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
 
 
 def _check_configuration() -> Optional[str]:
@@ -89,6 +147,9 @@ async def _run_interactive(assistant: GarvisAssistant, session_id: str) -> int:
 
 
 async def _run(args: argparse.Namespace) -> int:
+    if args.lattice_cycle is not None:
+        return _run_local_lattice_cycle(args)
+
     configuration_error = _check_configuration()
     if configuration_error:
         print(f"GARVIS configuration error: {configuration_error}", file=sys.stderr)

--- a/src/garvis/lattice_cycle_cli.py
+++ b/src/garvis/lattice_cycle_cli.py
@@ -1,0 +1,238 @@
+"""Local JSON adapter for the deterministic GARVIS lattice cycle.
+
+Authored under the direction of Adrien D. Thomas, operating as ProCityHub.
+
+This adapter reads an explicitly supplied evidence file and returns a bounded,
+machine-readable cognitive-cycle result. It does not contact an LLM, browse a
+network, execute an outside-world action, or convert conversation into evidence.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from .evidence_envelope import EvidenceEnvelope, build_evidence_envelope
+from .lattice_cognition import run_lattice_cognitive_cycle
+
+
+_ENVELOPE_FIELDS = {
+    "immutable_source_evidence",
+    "hypercube_cycle_data",
+    "deterministic_agi_measurements",
+    "scientific_claims",
+    "source_provenance_hashes",
+    "approval_state",
+    "garvis_evidence_summary",
+    "engineering_inference",
+    "symbolic_interpretation",
+    "unsupported_speculation",
+    "unknowns",
+}
+
+
+def _mapping_field(
+    payload: Mapping[str, Any],
+    field_name: str,
+    *,
+    required: bool = False,
+) -> dict[str, Any]:
+    if field_name not in payload:
+        if required:
+            raise ValueError(
+                f"evidence JSON requires {field_name!r}"
+            )
+        return {}
+
+    value = payload[field_name]
+
+    if not isinstance(value, Mapping):
+        raise ValueError(
+            f"{field_name!r} must contain a JSON object"
+        )
+
+    return dict(value)
+
+
+def load_evidence_envelope(path: Path) -> EvidenceEnvelope:
+    """Load and validate one explicit JSON evidence envelope."""
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ValueError(
+            f"unable to read evidence file {path}: {exc}"
+        ) from exc
+
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"evidence file is not valid JSON: {exc}"
+        ) from exc
+
+    if not isinstance(payload, Mapping):
+        raise ValueError(
+            "evidence JSON must contain one top-level object"
+        )
+
+    unknown_fields = sorted(
+        set(payload) - _ENVELOPE_FIELDS
+    )
+
+    if unknown_fields:
+        raise ValueError(
+            "unsupported evidence fields: "
+            + ", ".join(unknown_fields)
+        )
+
+    hypercube_data = payload.get("hypercube_cycle_data")
+
+    if (
+        hypercube_data is not None
+        and not isinstance(hypercube_data, Mapping)
+    ):
+        raise ValueError(
+            "'hypercube_cycle_data' must be an object or null"
+        )
+
+    return build_evidence_envelope(
+        immutable_source_evidence=_mapping_field(
+            payload,
+            "immutable_source_evidence",
+            required=True,
+        ),
+        hypercube_cycle_data=(
+            None
+            if hypercube_data is None
+            else dict(hypercube_data)
+        ),
+        deterministic_agi_measurements=_mapping_field(
+            payload,
+            "deterministic_agi_measurements",
+        ),
+        scientific_claims=_mapping_field(
+            payload,
+            "scientific_claims",
+        ),
+        source_provenance_hashes=_mapping_field(
+            payload,
+            "source_provenance_hashes",
+        ),
+        approval_state=_mapping_field(
+            payload,
+            "approval_state",
+        ),
+        garvis_evidence_summary=_mapping_field(
+            payload,
+            "garvis_evidence_summary",
+        ),
+        engineering_inference=_mapping_field(
+            payload,
+            "engineering_inference",
+        ),
+        symbolic_interpretation=_mapping_field(
+            payload,
+            "symbolic_interpretation",
+        ),
+        unsupported_speculation=_mapping_field(
+            payload,
+            "unsupported_speculation",
+        ),
+        unknowns=_mapping_field(
+            payload,
+            "unknowns",
+        ),
+    )
+
+
+def run_lattice_cycle_file(
+    *,
+    path: Path,
+    cycle: int,
+    external_action: bool,
+) -> dict[str, Any]:
+    """Run one local deterministic cycle and return JSON-ready output."""
+
+    envelope = load_evidence_envelope(path)
+
+    result = run_lattice_cognitive_cycle(
+        envelope=envelope,
+        cycle=cycle,
+        external_action=external_action,
+    )
+
+    equilibrium = result.recall_equilibrium.equilibrium
+
+    return {
+        "mode": "local_lattice_cycle",
+        "cycle": result.cycle,
+        "decision": result.decision,
+        "proposal_eligible": result.proposal_eligible,
+        "human_approval_required": (
+            result.human_approval_required
+        ),
+        "external_action_requested": bool(external_action),
+        "external_action_allowed": (
+            result.external_action_allowed
+        ),
+        "cycle_sha256": result.cycle_sha256,
+        "envelope_sha256": result.envelope_sha256,
+        "evidence": {
+            "sufficiency": (
+                result.assessment.evidence_sufficiency
+            ),
+            "signal_count": len(result.assessment.signals),
+            "retained_signal_count": len(
+                result.consolidated_memory.retained_signal_ids
+            ),
+            "excluded_signal_count": len(
+                result.consolidated_memory.excluded_signal_ids
+            ),
+        },
+        "pulse": {
+            "phase": result.pulse.phase.value,
+            "raw_union": result.pulse.raw_union,
+            "normalized_center": (
+                result.pulse.normalized_center
+            ),
+            "sha256": result.pulse.compute_sha256(),
+        },
+        "recall": {
+            "recalled": result.recall.recalled,
+            "converged": result.recall.converged,
+            "similarity": result.recall.similarity,
+            "cycles_run": result.recall.cycles_run,
+            "final_delta": result.recall.final_delta,
+            "sha256": (
+                result.recall_equilibrium.recall_sha256
+            ),
+        },
+        "equilibrium": {
+            "raw_union": equilibrium.raw_union,
+            "normalized_center": (
+                equilibrium.normalized_center
+            ),
+            "psychological_coherence": (
+                equilibrium.psychological_coherence
+            ),
+            "integrated_equilibrium": (
+                equilibrium.integrated_equilibrium
+            ),
+            "corner_bits": list(equilibrium.corner_bits),
+            "corner_index": equilibrium.corner_index,
+            "equilibrium_reached": (
+                equilibrium.equilibrium_reached
+            ),
+            "limiting_dimension": (
+                equilibrium.limiting_dimension
+            ),
+        },
+        "completed_stages": [
+            stage.value
+            for stage in result.completed_stages
+        ],
+        "claim_boundary": result.claim_boundary,
+    }

--- a/tests/test_lattice_cycle_cli.py
+++ b/tests/test_lattice_cycle_cli.py
@@ -1,0 +1,165 @@
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from garvis.cli import _run, build_parser
+from garvis.lattice_cycle_cli import load_evidence_envelope
+
+
+def write_strong_evidence(path: Path) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "immutable_source_evidence": {
+                    "ultimatum-result": {
+                        "status": "negative",
+                        "auc_phi": 0.871258,
+                        "auc_flat": 0.861944,
+                    }
+                },
+                "deterministic_agi_measurements": {
+                    "difference": 0.009314,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_parser_accepts_local_lattice_cycle(
+    tmp_path: Path,
+) -> None:
+    evidence_path = tmp_path / "evidence.json"
+
+    args = build_parser().parse_args(
+        [
+            "--lattice-cycle",
+            str(evidence_path),
+            "--cycle",
+            "7",
+            "--external-action",
+        ]
+    )
+
+    assert args.lattice_cycle == evidence_path
+    assert args.cycle == 7
+    assert args.external_action is True
+
+
+def test_local_cycle_does_not_require_openai_key(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    evidence_path = tmp_path / "evidence.json"
+    write_strong_evidence(evidence_path)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    args = build_parser().parse_args(
+        [
+            "--lattice-cycle",
+            str(evidence_path),
+            "--cycle",
+            "7",
+            "--external-action",
+        ]
+    )
+
+    code = asyncio.run(_run(args))
+    captured = capsys.readouterr()
+    output = json.loads(captured.out)
+
+    assert code == 0
+    assert captured.err == ""
+    assert output["mode"] == "local_lattice_cycle"
+    assert output["cycle"] == 7
+    assert output["pulse"]["raw_union"] == pytest.approx(1.6)
+    assert output["pulse"]["normalized_center"] == (
+        pytest.approx(1.0)
+    )
+    assert output["decision"] == "HUMAN_REVIEW_REQUIRED"
+    assert output["human_approval_required"] is True
+    assert output["external_action_allowed"] is False
+
+
+def test_lattice_cycle_rejects_conversation_prompt(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    evidence_path = tmp_path / "evidence.json"
+    write_strong_evidence(evidence_path)
+
+    args = build_parser().parse_args(
+        [
+            "--lattice-cycle",
+            str(evidence_path),
+            "answer",
+            "this",
+        ]
+    )
+
+    code = asyncio.run(_run(args))
+    captured = capsys.readouterr()
+
+    assert code == 2
+    assert captured.out == ""
+    assert "cannot be combined" in captured.err
+
+
+def test_invalid_json_returns_clear_cli_error(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    evidence_path = tmp_path / "invalid.json"
+    evidence_path.write_text("{not-json", encoding="utf-8")
+
+    args = build_parser().parse_args(
+        ["--lattice-cycle", str(evidence_path)]
+    )
+
+    code = asyncio.run(_run(args))
+    captured = capsys.readouterr()
+
+    assert code == 2
+    assert captured.out == ""
+    assert "not valid JSON" in captured.err
+
+
+def test_unknown_evidence_fields_are_rejected(
+    tmp_path: Path,
+) -> None:
+    evidence_path = tmp_path / "unknown.json"
+    evidence_path.write_text(
+        json.dumps(
+            {
+                "immutable_source_evidence": {
+                    "result": "observed"
+                },
+                "unregistered_field": {
+                    "value": 1
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="unsupported evidence fields",
+    ):
+        load_evidence_envelope(evidence_path)
+
+
+def test_local_adapter_has_no_execution_interface(
+    tmp_path: Path,
+) -> None:
+    evidence_path = tmp_path / "evidence.json"
+    write_strong_evidence(evidence_path)
+
+    envelope = load_evidence_envelope(evidence_path)
+
+    assert not hasattr(envelope, "execute")
+    assert not hasattr(envelope, "send")
+    assert not hasattr(envelope, "connect")


### PR DESCRIPTION
Authored under the direction of Adrien D. Thomas, operating as ProCityHub.

Adds an explicit local JSON command-line interface for the deterministic GARVIS lattice cognitive cycle.

It runs without an OpenAI API key, keeps evidence local, produces deterministic machine-readable results, requires human review for external-action proposals, and grants no external execution authority.

Classical engineering model only. No truth guarantee, biological-memory, consciousness, sentience, AGI, quantum, spiritual-proof, or clinical claim.

Adrien D. Thomas retains final merge authority.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a local, deterministic lattice-cycle mode to the CLI using JSON evidence files.
  - Added options to select the cycle and optionally enable an external action.
  - Outputs cycle decisions, permissions, evidence metrics, hashes, and completion details as formatted JSON.
  - Validates evidence files and reports clear errors for invalid or unsupported data.
  - Runs locally without requiring API credentials or performing network/external side effects.

- **Bug Fixes**
  - Improved synchronous execution reliability across event-loop environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->