### PR TITLE
Add GARVIS capability manifest

### DIFF
--- a/config/garvis_capabilities.json
+++ b/config/garvis_capabilities.json
@@ -1,0 +1,18 @@
+{
+  "identity": "GARVIS",
+  "authority": "Adrien D. Thomas",
+  "internet_access": "disabled",
+  "github_access": "disabled",
+  "financial_access": "disabled",
+  "memory": "sqlite_session",
+  "neural_learning": false,
+  "autonomous_goals": false,
+  "external_actions": "human_approval_required",
+  "consciousness_status": "unproven",
+  "evidence_policy": [
+    "verified",
+    "supplied",
+    "inferred",
+    "unknown"
+  ]
+}


### PR DESCRIPTION
Adds the GARVIS capability and authority manifest, including memory, internet, GitHub, financial-access, approval, evidence, and consciousness-status boundaries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Added GARVIS capability settings covering access controls, memory, learning, autonomy, and external-action approval.
  * Added evidence handling rules for verified, supplied, inferred, and unknown information.
  * Network, GitHub, and financial access remain disabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->