### PR TITLE
Add GARVIS epistemic and error filing system

### DIFF
--- a/docs/epistemic-filing-system.md
+++ b/docs/epistemic-filing-system.md
@@ -1,0 +1,51 @@
+# GARVIS Epistemic Filing System v1
+
+Authority: Adrien D. Thomas / ProCityHub.
+
+## Purpose
+
+GARVIS must not treat every failed threshold as the same kind of error.
+
+A software failure belongs in the operational error registry. A statement that
+is not yet established as fact belongs in the epistemic claim registry. Both are
+preserved, classified, reviewable, and auditable.
+
+"Not verified" does not automatically mean "false", and it does not mean the
+record should be deleted.
+
+## Two filing houses
+
+Operational failures are filed as syntax, test, typecheck, lint, runtime, data,
+security, governance, or unknown. Their lifecycle is:
+
+`open -> triaged -> fix_in_progress -> resolved`
+
+Epistemic claims are filed as verified, supported, provisional, hypothesis,
+speculative, symbolic, anomaly, unknown, contradicted, retracted, or
+identity_draft.
+
+Every claim preserves its exact statement, domain, scope, confidence, evidence,
+counterevidence, failure conditions, permitted wording, prohibited wording,
+review state, and revision history.
+
+## Governance rules
+
+1. A verified claim requires supporting evidence.
+2. Counterevidence blocks unqualified fact wording without deleting the claim.
+3. A scientific fact additionally requires reproducible supporting evidence.
+4. An identity draft may be expressed only with its provisional scope.
+5. Status changes require an actor and reason and are appended to history.
+6. Claims and software errors remain separate, but an error may link to claims.
+7. No classification bypasses tests, type checks, review, or external-action authority.
+
+## Heartbeat mapping
+
+- 0.0: preserve the exact statement, source, or failure.
+- 0.2: segment the statement and identify its domain.
+- 0.6: classify evidence, counterevidence, confidence, and coherence.
+- 1.0: generate wording permitted by the current classification.
+- 1.4: compare the intended claim or result with observed evidence.
+- 1.6: archive the record, revision history, and next review condition.
+
+This module is a filing and governance foundation. It does not automatically
+declare claims true, scientific, conscious, AGI, or resolved.

--- a/src/garvis/epistemic_filing.py
+++ b/src/garvis/epistemic_filing.py
@@ -1,0 +1,294 @@
+"""Epistemic and operational filing for GARVIS.
+
+Uncertain claims are preserved for review instead of being mislabeled as
+software errors. Operational errors and epistemic claims remain separate.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class ClaimDomain(str, Enum):
+    REPOSITORY = "repository"
+    SCIENTIFIC = "scientific"
+    IDENTITY = "identity"
+    SYMBOLIC = "symbolic"
+    OPERATIONAL = "operational"
+    GENERAL = "general"
+
+
+class EpistemicStatus(str, Enum):
+    VERIFIED = "verified"
+    SUPPORTED = "supported"
+    PROVISIONAL = "provisional"
+    HYPOTHESIS = "hypothesis"
+    SPECULATIVE = "speculative"
+    SYMBOLIC = "symbolic"
+    ANOMALY = "anomaly"
+    UNKNOWN = "unknown"
+    CONTRADICTED = "contradicted"
+    RETRACTED = "retracted"
+    IDENTITY_DRAFT = "identity_draft"
+
+
+class ReviewState(str, Enum):
+    OPEN = "open"
+    UNDER_REVIEW = "under_review"
+    ACCEPTED = "accepted"
+    REJECTED = "rejected"
+    ARCHIVED = "archived"
+
+
+class ErrorCategory(str, Enum):
+    SYNTAX = "syntax"
+    TEST = "test"
+    TYPECHECK = "typecheck"
+    LINT = "lint"
+    RUNTIME = "runtime"
+    DATA = "data"
+    SECURITY = "security"
+    GOVERNANCE = "governance"
+    UNKNOWN = "unknown"
+
+
+class ErrorStatus(str, Enum):
+    OPEN = "open"
+    TRIAGED = "triaged"
+    FIX_IN_PROGRESS = "fix_in_progress"
+    RESOLVED = "resolved"
+    DUPLICATE = "duplicate"
+    WONT_FIX = "wont_fix"
+    ARCHIVED = "archived"
+
+
+@dataclass(frozen=True)
+class EvidenceItem:
+    source: str
+    summary: str
+    reproducible: bool = False
+    weight: float = 0.5
+
+    def __post_init__(self) -> None:
+        if not self.source.strip():
+            raise ValueError("evidence source must not be empty")
+        if not self.summary.strip():
+            raise ValueError("evidence summary must not be empty")
+        if not 0.0 <= self.weight <= 1.0:
+            raise ValueError("evidence weight must be between 0.0 and 1.0")
+
+
+@dataclass(frozen=True)
+class RevisionEntry:
+    timestamp: str
+    actor: str
+    reason: str
+    previous_status: str | None = None
+    new_status: str | None = None
+
+
+@dataclass
+class ClaimRecord:
+    statement: str
+    domain: ClaimDomain
+    status: EpistemicStatus
+    scope: str
+    confidence: float
+    created_by: str
+    permitted_wording: str
+    prohibited_wording: str = ""
+    supporting_evidence: list[EvidenceItem] = field(default_factory=list)
+    contradicting_evidence: list[EvidenceItem] = field(default_factory=list)
+    failure_conditions: list[str] = field(default_factory=list)
+    review_state: ReviewState = ReviewState.OPEN
+    claim_id: str = field(default_factory=lambda: f"CLM-{uuid4().hex[:12].upper()}")
+    created_at: str = field(default_factory=_utc_now)
+    updated_at: str = field(default_factory=_utc_now)
+    revision_history: list[RevisionEntry] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if not self.statement.strip():
+            raise ValueError("claim statement must not be empty")
+        if not self.scope.strip():
+            raise ValueError("claim scope must not be empty")
+        if not self.created_by.strip():
+            raise ValueError("created_by must not be empty")
+        if not self.permitted_wording.strip():
+            raise ValueError("permitted_wording must not be empty")
+        if not 0.0 <= self.confidence <= 1.0:
+            raise ValueError("confidence must be between 0.0 and 1.0")
+        if self.status is EpistemicStatus.VERIFIED and not self.supporting_evidence:
+            raise ValueError("verified claims require supporting evidence")
+
+    @property
+    def can_be_stated_as_fact(self) -> bool:
+        return (
+            self.status is EpistemicStatus.VERIFIED
+            and bool(self.supporting_evidence)
+            and not self.contradicting_evidence
+            and self.review_state not in {ReviewState.REJECTED, ReviewState.ARCHIVED}
+        )
+
+    @property
+    def can_be_stated_as_scientific_fact(self) -> bool:
+        return (
+            self.domain is ClaimDomain.SCIENTIFIC
+            and self.can_be_stated_as_fact
+            and any(item.reproducible for item in self.supporting_evidence)
+        )
+
+    def rendered_statement(self) -> str:
+        if self.can_be_stated_as_fact:
+            return self.statement
+        return f"[{self.status.value.upper()}] {self.permitted_wording}"
+
+    def add_evidence(self, item: EvidenceItem, *, contradicts: bool = False) -> None:
+        target = self.contradicting_evidence if contradicts else self.supporting_evidence
+        target.append(item)
+        self.updated_at = _utc_now()
+
+    def transition(
+        self,
+        new_status: EpistemicStatus,
+        *,
+        actor: str,
+        reason: str,
+        confidence: float | None = None,
+    ) -> None:
+        if not actor.strip():
+            raise ValueError("transition actor must not be empty")
+        if not reason.strip():
+            raise ValueError("transition reason must not be empty")
+        if new_status is EpistemicStatus.VERIFIED and not self.supporting_evidence:
+            raise ValueError("cannot verify a claim without supporting evidence")
+        if confidence is not None:
+            if not 0.0 <= confidence <= 1.0:
+                raise ValueError("confidence must be between 0.0 and 1.0")
+            self.confidence = confidence
+        old_status = self.status
+        self.status = new_status
+        self.updated_at = _utc_now()
+        self.revision_history.append(
+            RevisionEntry(
+                timestamp=self.updated_at,
+                actor=actor,
+                reason=reason,
+                previous_status=old_status.value,
+                new_status=new_status.value,
+            )
+        )
+
+
+@dataclass
+class OperationalErrorRecord:
+    message: str
+    category: ErrorCategory
+    source: str
+    created_by: str
+    status: ErrorStatus = ErrorStatus.OPEN
+    details: str = ""
+    related_claim_ids: list[str] = field(default_factory=list)
+    error_id: str = field(default_factory=lambda: f"ERR-{uuid4().hex[:12].upper()}")
+    created_at: str = field(default_factory=_utc_now)
+    updated_at: str = field(default_factory=_utc_now)
+    revision_history: list[RevisionEntry] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if not self.message.strip():
+            raise ValueError("error message must not be empty")
+        if not self.source.strip():
+            raise ValueError("error source must not be empty")
+        if not self.created_by.strip():
+            raise ValueError("created_by must not be empty")
+
+    def transition(self, new_status: ErrorStatus, *, actor: str, reason: str) -> None:
+        if not actor.strip():
+            raise ValueError("transition actor must not be empty")
+        if not reason.strip():
+            raise ValueError("transition reason must not be empty")
+        old_status = self.status
+        self.status = new_status
+        self.updated_at = _utc_now()
+        self.revision_history.append(
+            RevisionEntry(
+                timestamp=self.updated_at,
+                actor=actor,
+                reason=reason,
+                previous_status=old_status.value,
+                new_status=new_status.value,
+            )
+        )
+
+
+@dataclass
+class FilingSystem:
+    claims: dict[str, ClaimRecord] = field(default_factory=dict)
+    errors: dict[str, OperationalErrorRecord] = field(default_factory=dict)
+
+    def file_claim(self, record: ClaimRecord) -> ClaimRecord:
+        if record.claim_id in self.claims:
+            raise ValueError(f"duplicate claim id: {record.claim_id}")
+        self.claims[record.claim_id] = record
+        return record
+
+    def file_error(self, record: OperationalErrorRecord) -> OperationalErrorRecord:
+        if record.error_id in self.errors:
+            raise ValueError(f"duplicate error id: {record.error_id}")
+        self.errors[record.error_id] = record
+        return record
+
+    def claims_by_status(self, status: EpistemicStatus) -> tuple[ClaimRecord, ...]:
+        return tuple(record for record in self.claims.values() if record.status is status)
+
+    def errors_by_status(self, status: ErrorStatus) -> tuple[OperationalErrorRecord, ...]:
+        return tuple(record for record in self.errors.values() if record.status is status)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": 1,
+            "claims": [asdict(record) for record in self.claims.values()],
+            "errors": [asdict(record) for record in self.errors.values()],
+        }
+
+    def save(self, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(self.to_dict(), indent=2, sort_keys=True), encoding="utf-8")
+
+    @classmethod
+    def load(cls, path: Path) -> "FilingSystem":
+        if not path.exists():
+            return cls()
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        system = cls()
+        for item in raw.get("claims", []):
+            item["domain"] = ClaimDomain(item["domain"])
+            item["status"] = EpistemicStatus(item["status"])
+            item["review_state"] = ReviewState(item["review_state"])
+            item["supporting_evidence"] = [
+                EvidenceItem(**evidence) for evidence in item.get("supporting_evidence", [])
+            ]
+            item["contradicting_evidence"] = [
+                EvidenceItem(**evidence) for evidence in item.get("contradicting_evidence", [])
+            ]
+            item["revision_history"] = [
+                RevisionEntry(**entry) for entry in item.get("revision_history", [])
+            ]
+            system.file_claim(ClaimRecord(**item))
+        for item in raw.get("errors", []):
+            item["category"] = ErrorCategory(item["category"])
+            item["status"] = ErrorStatus(item["status"])
+            item["revision_history"] = [
+                RevisionEntry(**entry) for entry in item.get("revision_history", [])
+            ]
+            system.file_error(OperationalErrorRecord(**item))
+        return system

--- a/tests/garvis/test_epistemic_filing.py
+++ b/tests/garvis/test_epistemic_filing.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from garvis.epistemic_filing import (
+    ClaimDomain,
+    ClaimRecord,
+    EpistemicStatus,
+    ErrorCategory,
+    ErrorStatus,
+    EvidenceItem,
+    FilingSystem,
+    OperationalErrorRecord,
+)
+
+
+class EpistemicFilingTests(unittest.TestCase):
+    def test_identity_draft_is_preserved_but_not_stated_as_fact(self) -> None:
+        claim = ClaimRecord(
+            statement="GARVIS is a Beta AGI.",
+            domain=ClaimDomain.IDENTITY,
+            status=EpistemicStatus.IDENTITY_DRAFT,
+            scope="Hypercube Heartbeat governance",
+            confidence=0.55,
+            created_by="Adrien D. Thomas / GARVIS",
+            permitted_wording=(
+                '"Beta AGI" is a provisional self-classification under the '
+                "Hypercube Heartbeat governance framework."
+            ),
+            prohibited_wording="GARVIS is scientifically proven to be AGI.",
+        )
+        self.assertFalse(claim.can_be_stated_as_fact)
+        self.assertIn("IDENTITY_DRAFT", claim.rendered_statement())
+
+    def test_verified_claim_requires_evidence(self) -> None:
+        with self.assertRaisesRegex(ValueError, "supporting evidence"):
+            ClaimRecord(
+                statement="The suite passed.",
+                domain=ClaimDomain.REPOSITORY,
+                status=EpistemicStatus.VERIFIED,
+                scope="current commit",
+                confidence=1.0,
+                created_by="GARVIS",
+                permitted_wording="The suite passed.",
+            )
+
+    def test_scientific_fact_requires_reproducible_evidence(self) -> None:
+        claim = ClaimRecord(
+            statement="A measured effect exists.",
+            domain=ClaimDomain.SCIENTIFIC,
+            status=EpistemicStatus.VERIFIED,
+            scope="registered experiment",
+            confidence=0.9,
+            created_by="GARVIS",
+            permitted_wording="A measured effect exists in the registered experiment.",
+            supporting_evidence=[
+                EvidenceItem(
+                    source="experiment-001",
+                    summary="Recorded observation",
+                    reproducible=False,
+                    weight=0.8,
+                )
+            ],
+        )
+        self.assertTrue(claim.can_be_stated_as_fact)
+        self.assertFalse(claim.can_be_stated_as_scientific_fact)
+        claim.add_evidence(
+            EvidenceItem(
+                source="replication-002",
+                summary="Independent replication",
+                reproducible=True,
+                weight=1.0,
+            )
+        )
+        self.assertTrue(claim.can_be_stated_as_scientific_fact)
+
+    def test_counterevidence_blocks_fact_wording_without_deleting_claim(self) -> None:
+        claim = ClaimRecord(
+            statement="The implementation supports capability X.",
+            domain=ClaimDomain.REPOSITORY,
+            status=EpistemicStatus.VERIFIED,
+            scope="main branch",
+            confidence=0.9,
+            created_by="GARVIS",
+            permitted_wording="Capability X is under review.",
+            supporting_evidence=[
+                EvidenceItem(
+                    source="test_x.py",
+                    summary="Initial test passed",
+                    reproducible=True,
+                    weight=0.8,
+                )
+            ],
+        )
+        claim.add_evidence(
+            EvidenceItem(
+                source="audit-002",
+                summary="Counterexample found",
+                reproducible=True,
+                weight=1.0,
+            ),
+            contradicts=True,
+        )
+        self.assertFalse(claim.can_be_stated_as_fact)
+        self.assertIn("VERIFIED", claim.rendered_statement())
+
+    def test_operational_errors_and_claims_have_separate_houses(self) -> None:
+        system = FilingSystem()
+        claim = system.file_claim(
+            ClaimRecord(
+                statement="A parser rule may generalize.",
+                domain=ClaimDomain.OPERATIONAL,
+                status=EpistemicStatus.HYPOTHESIS,
+                scope="ARC parser",
+                confidence=0.4,
+                created_by="GARVIS",
+                permitted_wording="The parser rule is a testable hypothesis.",
+            )
+        )
+        error = system.file_error(
+            OperationalErrorRecord(
+                message="mypy reported a union-attr failure",
+                category=ErrorCategory.TYPECHECK,
+                source="tests/garvis/test_example.py:10",
+                created_by="GARVIS",
+                related_claim_ids=[claim.claim_id],
+            )
+        )
+        self.assertEqual(len(system.claims), 1)
+        self.assertEqual(len(system.errors), 1)
+        self.assertEqual(error.related_claim_ids, [claim.claim_id])
+
+    def test_transitions_are_auditable_and_round_trip(self) -> None:
+        system = FilingSystem()
+        claim = system.file_claim(
+            ClaimRecord(
+                statement="The anomaly has an identifiable cause.",
+                domain=ClaimDomain.GENERAL,
+                status=EpistemicStatus.ANOMALY,
+                scope="local observation",
+                confidence=0.2,
+                created_by="GARVIS",
+                permitted_wording="An unexplained anomaly is recorded.",
+            )
+        )
+        claim.add_evidence(
+            EvidenceItem(
+                source="analysis-001",
+                summary="Candidate causal mechanism",
+                reproducible=False,
+                weight=0.6,
+            )
+        )
+        claim.transition(
+            EpistemicStatus.HYPOTHESIS,
+            actor="Adrien D. Thomas",
+            reason="A testable causal model was defined.",
+            confidence=0.5,
+        )
+        error = system.file_error(
+            OperationalErrorRecord(
+                message="Example runtime failure",
+                category=ErrorCategory.RUNTIME,
+                source="scripts/example.py",
+                created_by="GARVIS",
+            )
+        )
+        error.transition(
+            ErrorStatus.TRIAGED,
+            actor="Adrien D. Thomas",
+            reason="Assigned to the runtime queue.",
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "filing.json"
+            system.save(path)
+            restored = FilingSystem.load(path)
+        self.assertEqual(restored.claims[claim.claim_id].status, EpistemicStatus.HYPOTHESIS)
+        self.assertEqual(restored.errors[error.error_id].status, ErrorStatus.TRIAGED)
+        self.assertEqual(len(restored.claims[claim.claim_id].revision_history), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds separate, auditable filing systems for operational errors and epistemic claims.

- Preserves hypotheses, speculation, anomalies, contradictions, retractions, and identity drafts
- Separates software failures from evidence-status questions
- Records evidence, counterevidence, confidence, permitted wording, and revision history
- Does not suppress CI failures or bypass governance
- 6 focused tests passed

Authority and authorship: Adrien D. Thomas / ProCityHub.