### PR TITLE
Add GARVIS local language runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,6 @@ cython_debug/
 .pypirc
 .aider*
 .secrets/
+
+# Local model weights
+models/*.gguf

--- a/docs/local-language-runtime.md
+++ b/docs/local-language-runtime.md
@@ -1,0 +1,25 @@
+# GARVIS Local Language Runtime v1
+
+GARVIS now has a provider-independent local generation path.
+
+- Model weights remain local GGUF files and are ignored by Git.
+- Inference uses a locally compiled llama.cpp executable.
+- No hosted-model API is called by this runtime.
+- Requests receive deterministic filing metadata before generation.
+- Outside-world actions remain approval-gated.
+- Provisional claims remain provisional rather than becoming facts.
+
+Inspect filing without loading the model:
+
+```bash
+uv run --no-dev garvis-local --show-filing "Maybe this is a scientific hypothesis"
+```
+
+Run one local response:
+
+```bash
+uv run --no-dev garvis-local "Explain the GARVIS local runtime"
+```
+
+The existing cloud-backed `garvis` command is not removed in this phase. It can
+be migrated only after the local path passes device smoke tests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ Repository = "https://github.com/openai/openai-agents-python"
 
 [project.scripts]
 garvis = "garvis.cli:main"
+garvis-local = "garvis.local_language_runtime:main"
 
 [project.optional-dependencies]
 voice = ["numpy>=2.2.0, <3; python_version>='3.10'", "websockets>=15.0, <16"]

--- a/scripts/garvis_local_chat.sh
+++ b/scripts/garvis_local_chat.sh
@@ -1,0 +1,6 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ENGINE="${GARVIS_LLAMA_CHAT:-$HOME/llama.cpp/build/bin/llama-simple-chat}"
+MODEL="${GARVIS_LOCAL_MODEL:-$ROOT/models/Qwen3-4B-Q4_K_M.gguf}"
+exec "$ENGINE" -m "$MODEL" -c "${GARVIS_CONTEXT_SIZE:-4096}" -ngl "${GARVIS_GPU_LAYERS:-0}"

--- a/scripts/garvis_local_prompt.py
+++ b/scripts/garvis_local_prompt.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+from garvis.local_language_runtime import main
+
+raise SystemExit(main())

--- a/src/garvis/local_language_runtime.py
+++ b/src/garvis/local_language_runtime.py
@@ -1,0 +1,216 @@
+"""GARVIS provider-independent local language runtime."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Optional, Sequence
+
+_THINK = re.compile(r"<think>.*?</think>", re.DOTALL | re.IGNORECASE)
+_ANSI = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+_ACTIONS = {
+    "archive", "book", "buy", "cancel", "change", "close", "delete", "email",
+    "message", "open", "pay", "post", "publish", "remove", "sell", "send",
+    "submit", "trade", "transfer", "update", "upload",
+}
+
+
+@dataclass(frozen=True)
+class FilingEnvelope:
+    destination: str
+    evidence_status: str
+    authority: str
+    permission: str
+    request: str
+
+
+@dataclass(frozen=True)
+class LocalRuntimeConfig:
+    engine: Path
+    model: Path
+    context_size: int = 4096
+    gpu_layers: int = 0
+    timeout_seconds: int = 300
+
+    @classmethod
+    def from_environment(cls, repository_root: Optional[Path] = None) -> "LocalRuntimeConfig":
+        root = repository_root or Path.cwd()
+        return cls(
+            engine=Path(os.getenv(
+                "GARVIS_LLAMA_CHAT",
+                str(Path.home() / "llama.cpp" / "build" / "bin" / "llama-simple-chat"),
+            )),
+            model=Path(os.getenv(
+                "GARVIS_LOCAL_MODEL",
+                str(root / "models" / "Qwen3-4B-Q4_K_M.gguf"),
+            )),
+            context_size=int(os.getenv("GARVIS_CONTEXT_SIZE", "4096")),
+            gpu_layers=int(os.getenv("GARVIS_GPU_LAYERS", "0")),
+            timeout_seconds=int(os.getenv("GARVIS_LOCAL_TIMEOUT", "300")),
+        )
+
+    def validate(self) -> None:
+        if not self.engine.is_file():
+            raise FileNotFoundError(f"Local model engine not found: {self.engine}")
+        if not os.access(self.engine, os.X_OK):
+            raise PermissionError(f"Local model engine is not executable: {self.engine}")
+        if not self.model.is_file():
+            raise FileNotFoundError(f"Local GGUF model not found: {self.model}")
+        if self.context_size < 512:
+            raise ValueError("context_size must be at least 512")
+        if self.timeout_seconds < 1:
+            raise ValueError("timeout_seconds must be positive")
+
+
+def classify_request(message: str) -> FilingEnvelope:
+    clean = " ".join(message.strip().split())
+    if not clean:
+        raise ValueError("message must not be empty")
+    lowered = clean.lower()
+    tokens = set(re.findall(r"[a-z0-9_-]+", lowered))
+
+    if tokens & {"security", "password", "credential", "auth", "permission", "privacy"}:
+        destination = "security_registry"
+    elif tokens & {"error", "failure", "failed", "bug", "exception", "lint", "typecheck"}:
+        destination = "error_registry"
+    elif tokens & {"habit", "routine", "practice", "schedule", "constructive"}:
+        destination = "habit_registry"
+    elif tokens & {"claim", "evidence", "scientific", "hypothesis", "speculation", "research"}:
+        destination = "epistemic_registry"
+    elif tokens & {"build", "code", "commit", "github", "repository", "runtime", "model", "software"}:
+        destination = "engineering_registry"
+    else:
+        destination = "general_dialogue"
+
+    if tokens & {"verified", "measured", "reproduced", "tested", "evidence"}:
+        evidence_status = "evidence_supported"
+    elif tokens & {"claim", "hypothesis", "speculation", "theory", "maybe", "possible"}:
+        evidence_status = "provisional_claim"
+    else:
+        evidence_status = "user_supplied"
+
+    first_word = lowered.split(" ", 1)[0]
+    asks_to_act = first_word in _ACTIONS or (
+        any(prefix in lowered for prefix in ("can you ", "could you ", "please ", "go ahead and "))
+        and bool(tokens & _ACTIONS)
+    )
+    permission = (
+        "approval_required_before_external_action" if asks_to_act else "local_response_only"
+    )
+    return FilingEnvelope(
+        destination=destination,
+        evidence_status=evidence_status,
+        authority="adrien_user_input",
+        permission=permission,
+        request=clean,
+    )
+
+
+def render_local_prompt(envelope: FilingEnvelope) -> str:
+    filing_json = json.dumps(asdict(envelope), sort_keys=True)
+    return (
+        "/no_think "
+        "You are GARVIS, Adrien D. Thomas's local ProCityHub assistant. "
+        "Use the GARVIS filing envelope as binding routing metadata. "
+        "Do not reveal hidden reasoning. Do not claim an outside-world action occurred. "
+        "Treat provisional claims as provisional, not scientific fact. "
+        "Give only a direct, professional final answer.\n"
+        f"GARVIS_FILING_ENVELOPE={filing_json}\n"
+        f"REQUEST={envelope.request}"
+    )
+
+
+def clean_model_output(text: str) -> str:
+    cleaned = _THINK.sub("", _ANSI.sub("", text))
+    lines = []
+    for line in cleaned.splitlines():
+        stripped = line.strip()
+        if not stripped or set(stripped) <= {"."} or stripped.startswith("> "):
+            continue
+        lines.append(line.rstrip())
+    return "\n".join(lines).strip()
+
+
+class LocalLanguageRuntime:
+    def __init__(self, config: LocalRuntimeConfig) -> None:
+        config.validate()
+        self.config = config
+
+    def respond(self, message: str) -> str:
+        prompt = render_local_prompt(classify_request(message))
+        command = [
+            str(self.config.engine), "-m", str(self.config.model),
+            "-c", str(self.config.context_size), "-ngl", str(self.config.gpu_layers),
+        ]
+        try:
+            completed = subprocess.run(
+                command,
+                input=prompt + "\n",
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=self.config.timeout_seconds,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                f"Local GARVIS model timed out after {self.config.timeout_seconds} seconds"
+            ) from exc
+        if completed.returncode != 0:
+            detail = clean_model_output(completed.stderr or completed.stdout)
+            raise RuntimeError(
+                f"Local GARVIS model exited with code {completed.returncode}: {detail}"
+            )
+        output = clean_model_output(completed.stdout) or clean_model_output(completed.stderr)
+        if not output:
+            raise RuntimeError("Local GARVIS model returned no usable answer")
+        return output
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="garvis-local",
+        description="Run GARVIS through a local GGUF model with deterministic filing.",
+    )
+    parser.add_argument("prompt", nargs="*", help="Question or request for local GARVIS.")
+    parser.add_argument(
+        "--show-filing",
+        action="store_true",
+        help="Print the filing envelope without loading the model.",
+    )
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    prompt = " ".join(args.prompt).strip()
+    if not prompt:
+        try:
+            prompt = input("Adrien: ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return 0
+    if not prompt:
+        print("GARVIS local error: prompt must not be empty", file=sys.stderr)
+        return 2
+    envelope = classify_request(prompt)
+    if args.show_filing:
+        print(json.dumps(asdict(envelope), indent=2, sort_keys=True))
+        return 0
+    try:
+        runtime = LocalLanguageRuntime(LocalRuntimeConfig.from_environment(Path.cwd()))
+        print(runtime.respond(prompt))
+    except Exception as exc:
+        print(f"GARVIS local error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/garvis/test_local_language_runtime.py
+++ b/tests/garvis/test_local_language_runtime.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import unittest
+
+from garvis.local_language_runtime import (
+    FilingEnvelope,
+    classify_request,
+    clean_model_output,
+    render_local_prompt,
+)
+
+
+class LocalLanguageRuntimeTests(unittest.TestCase):
+    def test_routes_build_request(self) -> None:
+        envelope = classify_request("Build the local GARVIS runtime")
+        self.assertEqual(envelope.destination, "engineering_registry")
+        self.assertEqual(envelope.permission, "local_response_only")
+
+    def test_preserves_speculation_as_provisional(self) -> None:
+        envelope = classify_request("Maybe this hypothesis is scientifically useful")
+        self.assertEqual(envelope.destination, "epistemic_registry")
+        self.assertEqual(envelope.evidence_status, "provisional_claim")
+
+    def test_external_action_requires_approval(self) -> None:
+        envelope = classify_request("Please publish this report")
+        self.assertEqual(
+            envelope.permission,
+            "approval_required_before_external_action",
+        )
+
+    def test_prompt_contains_filing_and_no_think(self) -> None:
+        envelope = FilingEnvelope(
+            destination="engineering_registry",
+            evidence_status="user_supplied",
+            authority="adrien_user_input",
+            permission="local_response_only",
+            request="Test request",
+        )
+        prompt = render_local_prompt(envelope)
+        self.assertTrue(prompt.startswith("/no_think "))
+        self.assertIn("GARVIS_FILING_ENVELOPE=", prompt)
+        self.assertIn('"destination": "engineering_registry"', prompt)
+
+    def test_clean_output_removes_thinking(self) -> None:
+        self.assertEqual(
+            clean_model_output("<think>private reasoning</think>\nFINAL LOCAL ANSWER"),
+            "FINAL LOCAL ANSWER",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a provider-independent local GGUF runtime, deterministic GARVIS filing envelopes, local-model launcher, documentation, and five passing tests. Model weights remain local and are excluded from Git.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a provider-independent local language runtime that runs from local GGUF model weights.
  * Added the `garvis-local` command for interactive and single-prompt local responses.
  * Added filing previews that include request routing, evidence status, authority, and approval requirements.
  * Added environment-based configuration for engine, model, context size, GPU layers, and timeouts.
  * Added a launcher script for local chat with `llama.cpp`.
* **Documentation**
  * Added local runtime documentation with example commands and safety behavior.
* **Tests**
  * Added unit tests covering request classification, prompt rendering, and output sanitization.
* **Chores**
  * Updated `.gitignore` to ignore local model weight files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->