### PR TITLE
Make local GARVIS the default CLI runtime

### DIFF
--- a/src/garvis/cli.py
+++ b/src/garvis/cli.py
@@ -7,17 +7,23 @@ import asyncio
 import json
 import os
 import sys
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Optional, Sequence
+from typing import TYPE_CHECKING
 
-from .assistant import DEFAULT_MODEL, GarvisAssistant, GarvisResponseError
 from .lattice_cycle_cli import run_lattice_cycle_file
+
+if TYPE_CHECKING:
+    from .assistant import GarvisAssistant
+    from .local_language_runtime import LocalLanguageRuntime
+
+DEFAULT_REMOTE_MODEL = "gpt-5.1"
 
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="garvis",
-        description="Run GARVIS as a direct conversational assistant.",
+        description="Run GARVIS locally by default, with an explicit remote fallback.",
     )
     parser.add_argument("prompt", nargs="*", help="Question or request for GARVIS.")
     parser.add_argument(
@@ -26,9 +32,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="Start an interactive conversation. This is the default when no prompt is supplied.",
     )
     parser.add_argument(
+        "--remote",
+        action="store_true",
+        help="Use the legacy remote provider runtime instead of the local GGUF runtime.",
+    )
+    parser.add_argument(
         "--model",
-        default=os.getenv("GARVIS_MODEL", DEFAULT_MODEL),
-        help="OpenAI model name. Defaults to GARVIS_MODEL or %(default)s.",
+        default=os.getenv("GARVIS_MODEL", DEFAULT_REMOTE_MODEL),
+        help="Remote model name used only with --remote. Default: %(default)s.",
     )
     parser.add_argument(
         "--session",
@@ -105,11 +116,67 @@ def _run_local_lattice_cycle(args: argparse.Namespace) -> int:
     return 0
 
 
-def _check_configuration(model: Optional[str] = None) -> Optional[str]:
-    from .anthropic_backend import is_anthropic_model
-    from .assistant import DEFAULT_MODEL
+def _build_local_runtime() -> LocalLanguageRuntime:
+    from .local_language_runtime import LocalLanguageRuntime, LocalRuntimeConfig
 
-    resolved = model or os.getenv("GARVIS_MODEL", DEFAULT_MODEL)
+    return LocalLanguageRuntime(LocalRuntimeConfig.from_environment(Path.cwd()))
+
+
+def _configure_local_memory(args: argparse.Namespace) -> None:
+    os.environ["GARVIS_MEMORY_ENABLED"] = "0" if args.no_memory else "1"
+    if args.db is not None:
+        os.environ["GARVIS_MEMORY_DB"] = str(args.db.expanduser())
+
+
+def _run_local_interactive(runtime: LocalLanguageRuntime) -> int:
+    print("GARVIS local is active. Type /exit to end the session.")
+    while True:
+        try:
+            prompt = input("Adrien: ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return 0
+
+        if not prompt:
+            continue
+        if prompt.lower() in {"/exit", "/quit"}:
+            return 0
+
+        try:
+            reply = runtime.respond(prompt)
+        except Exception as exc:
+            print(f"GARVIS local error: {exc}", file=sys.stderr)
+            continue
+
+        print("GARVIS:")
+        print(reply)
+
+
+def _run_local(args: argparse.Namespace) -> int:
+    _configure_local_memory(args)
+
+    try:
+        runtime = _build_local_runtime()
+    except Exception as exc:
+        print(f"GARVIS local configuration error: {exc}", file=sys.stderr)
+        return 2
+
+    prompt = " ".join(args.prompt).strip()
+    if not prompt:
+        return _run_local_interactive(runtime)
+
+    try:
+        print(runtime.respond(prompt))
+    except Exception as exc:
+        print(f"GARVIS local error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+def _check_configuration(model: str | None = None) -> str | None:
+    from .anthropic_backend import is_anthropic_model
+
+    resolved = model or os.getenv("GARVIS_MODEL", DEFAULT_REMOTE_MODEL)
     if is_anthropic_model(resolved):
         if not os.getenv("ANTHROPIC_API_KEY"):
             return (
@@ -128,7 +195,7 @@ def _check_configuration(model: Optional[str] = None) -> Optional[str]:
     return None
 
 
-def _print_reply(text: str, requires_approval: bool, approval_reason: Optional[str]) -> None:
+def _print_reply(text: str, requires_approval: bool, approval_reason: str | None) -> None:
     print(text)
     if requires_approval:
         print("\n[Execution status: approval required before any outside-world action.]")
@@ -163,6 +230,10 @@ async def _run_interactive(assistant: GarvisAssistant, session_id: str) -> int:
 async def _run(args: argparse.Namespace) -> int:
     if args.lattice_cycle is not None:
         return _run_local_lattice_cycle(args)
+    if not args.remote:
+        return _run_local(args)
+
+    from .assistant import GarvisAssistant
 
     configuration_error = _check_configuration(args.model)
     if configuration_error:
@@ -189,7 +260,7 @@ async def _run(args: argparse.Namespace) -> int:
     return await _run_interactive(assistant, args.session)
 
 
-def main(argv: Optional[Sequence[str]] = None) -> int:
+def main(argv: Sequence[str] | None = None) -> int:
     """CLI entry point."""
 
     args = build_parser().parse_args(argv)

--- a/tests/garvis/test_cli.py
+++ b/tests/garvis/test_cli.py
@@ -1,20 +1,60 @@
-from garvis.cli import build_parser
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from garvis import cli
+
+
+class FakeLocalRuntime:
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    def respond(self, message: str) -> str:
+        self.messages.append(message)
+        return f"local reply: {message}"
 
 
 def test_cli_accepts_one_shot_prompt() -> None:
-    args = build_parser().parse_args(["What", "is", "GARVIS?"])
+    args = cli.build_parser().parse_args(["What", "is", "GARVIS?"])
 
     assert args.prompt == ["What", "is", "GARVIS?"]
+    assert args.remote is False
     assert args.session == "default"
     assert args.no_memory is False
 
 
-def test_cli_supports_memory_and_model_options() -> None:
-    args = build_parser().parse_args(
-        ["--model", "test-model", "--session", "adrien", "--no-memory", "hello"]
+def test_cli_supports_remote_memory_and_model_options() -> None:
+    args = cli.build_parser().parse_args(
+        [
+            "--remote",
+            "--model",
+            "test-model",
+            "--session",
+            "adrien",
+            "--no-memory",
+            "hello",
+        ]
     )
 
+    assert args.remote is True
     assert args.model == "test-model"
     assert args.session == "adrien"
     assert args.no_memory is True
     assert args.prompt == ["hello"]
+
+
+def test_default_run_uses_local_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    runtime = FakeLocalRuntime()
+    monkeypatch.setattr(cli, "_build_local_runtime", lambda: runtime)
+
+    args = cli.build_parser().parse_args(["hello"])
+    result = asyncio.run(cli._run(args))
+
+    assert result == 0
+    assert runtime.messages == ["hello"]
+    assert capsys.readouterr().out.strip() == "local reply: hello"


### PR DESCRIPTION
Makes the in-house local GGUF runtime the default for the garvis command, preserves memory and safety boundaries, and keeps remote providers available only through the explicit --remote flag. Ruff, 16 focused tests, and mypy all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The CLI now runs with a local runtime by default.
  * Added a `--remote` option to use the remote provider when needed.
  * Local sessions support both prompts and interactive conversations, including `/exit` and `/quit`.
  * Added configurable local memory settings, including an optional database path.

* **Bug Fixes**
  * Local runtime errors now produce concise stderr messages and appropriate exit codes.

* **Tests**
  * Added coverage for local execution, remote options, prompts, and CLI argument parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->