### PR TITLE
Keep one-shot approvals inside GARVIS

### DIFF
--- a/src/garvis/cli.py
+++ b/src/garvis/cli.py
@@ -168,7 +168,21 @@ def _run_local(args: argparse.Namespace) -> int:
         return _run_local_interactive(runtime)
 
     try:
-        print(runtime.respond(prompt))
+        reply = runtime.respond(prompt)
+        print(reply)
+
+        if "Approve? [Y/N]" in reply:
+            try:
+                approval = input().strip()
+            except (EOFError, KeyboardInterrupt):
+                print()
+                return 0
+
+            if approval.casefold() not in {"y", "yes", "n", "no"}:
+                print("GARVIS approval cancelled: enter Y or N.", file=sys.stderr)
+                return 2
+
+            print(runtime.respond(approval))
     except Exception as exc:
         print(f"GARVIS local error: {exc}", file=sys.stderr)
         return 1
@@ -257,6 +271,33 @@ async def _run(args: argparse.Namespace) -> int:
             return 1
 
         _print_reply(reply.text, reply.requires_approval, reply.approval_reason)
+
+        if reply.requires_approval:
+            try:
+                approval = input().strip()
+            except (EOFError, KeyboardInterrupt):
+                print()
+                return 0
+
+            if approval.casefold() not in {"y", "yes", "n", "no"}:
+                print("GARVIS approval cancelled: enter Y or N.", file=sys.stderr)
+                return 2
+
+            try:
+                reply = await assistant.respond(
+                    approval,
+                    session_id=args.session,
+                )
+            except Exception as exc:
+                print(f"GARVIS error: {exc}", file=sys.stderr)
+                return 1
+
+            _print_reply(
+                reply.text,
+                reply.requires_approval,
+                reply.approval_reason,
+            )
+
         return 0
 
     return await _run_interactive(assistant, args.session)

--- a/tests/garvis/test_cli.py
+++ b/tests/garvis/test_cli.py
@@ -58,3 +58,36 @@ def test_default_run_uses_local_runtime(
     assert result == 0
     assert runtime.messages == ["hello"]
     assert capsys.readouterr().out.strip() == "local reply: hello"
+
+
+class FakeApprovalRuntime:
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    def respond(self, message: str) -> str:
+        self.messages.append(message)
+        if len(self.messages) == 1:
+            return "GARVIS requests internet research permission.\n\nApprove? [Y/N]"
+        return "Approved research answer."
+
+
+def test_local_one_shot_consumes_approval(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    runtime = FakeApprovalRuntime()
+    monkeypatch.setattr(cli, "_build_local_runtime", lambda: runtime)
+    monkeypatch.setattr("builtins.input", lambda: "y")
+
+    args = cli.build_parser().parse_args(["research", "current", "drywall", "prices"])
+    result = asyncio.run(cli._run(args))
+
+    assert result == 0
+    assert runtime.messages == [
+        "research current drywall prices",
+        "y",
+    ]
+
+    output = capsys.readouterr().out
+    assert "Approve? [Y/N]" in output
+    assert output.rstrip().endswith("Approved research answer.")


### PR DESCRIPTION
Keeps Y/N approval inside the local one-shot GARVIS process, executes the approved research request in the same session, and adds a regression test. Ruff passed and 11 focused tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive approval handling for local and remote responses that require confirmation.
  * Users can approve or reject requests directly in the CLI before receiving the final response.
  * Added input validation for approval prompts.

* **Bug Fixes**
  * Ensured approval-required responses are completed and displayed instead of ending prematurely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->