### PR TITLE
Hide private memory records from GARVIS replies

### DIFF
--- a/src/garvis/local_language_runtime.py
+++ b/src/garvis/local_language_runtime.py
@@ -187,34 +187,48 @@ def render_local_prompt(
 
 def clean_model_output(text: str) -> str:
     cleaned = _THINK.sub("", _ANSI.sub("", text))
-
-    legacy_markers = (
+    legacy_markers = {
         "GARVIS_FILING_ENVELOPE=",
-        "GARVIS_MEMORY_CONTEXT_BEGIN=",
+        "GARVIS_MEMORY_CONTEXT_BEGIN",
         "GARVIS_MEMORY_CONTEXT_END",
-        "GARVIS_EXTERNAL_EVIDENCE_BEGIN=",
+        "GARVIS_EXTERNAL_EVIDENCE_BEGIN",
         "GARVIS_EXTERNAL_EVIDENCE_END",
         "REQUEST=",
-    )
+    }
     hidden_prefixes = (
         "/no_think",
-        "You are GARVIS,",
+        "You are GARVIS.",
         "Operate with ",
         "Treat the request as ",
         "Use this fallible recalled context",
         "Use this external evidence",
         "User request:",
     )
+    private_memory_headers = (
+        "storage of research conclusions",
+        "internal memory records",
+        "recalled memory records",
+    )
 
-    lines = []
+    lines: list[str] = []
     for line in cleaned.splitlines():
         stripped = line.strip()
-        if not stripped or set(stripped) <= {">"}:
+        if not stripped or set(stripped) <= {"."}:
             continue
         if any(marker in stripped for marker in legacy_markers):
             continue
         if stripped.startswith(hidden_prefixes):
             continue
+
+        plain = stripped.strip("*_`#> -")
+        lowered = plain.casefold()
+        label = lowered.split(":", 1)[0].strip()
+
+        if any(lowered.startswith(header) for header in private_memory_headers):
+            break
+        if label in {"memory id", "memory_id"}:
+            break
+
         lines.append(line.rstrip())
 
     answer = "\n".join(lines).strip()

--- a/tests/garvis/test_private_memory_output.py
+++ b/tests/garvis/test_private_memory_output.py
@@ -1,0 +1,23 @@
+from garvis.local_language_runtime import clean_model_output
+
+
+def test_clean_model_output_hides_private_memory_dump() -> None:
+    output = clean_model_output(
+        """Research thesis summary.
+
+The recommended upgrade requires Adrien's approval.
+
+**Storage of Research Conclusions**
+**Memory ID**: 49
+**Kind**: Semantic
+**Evidence**: Evidence Supported
+**Source**: Internet Research
+**Content**: Private recalled memory
+"""
+    )
+
+    assert output == (
+        "Research thesis summary.\nThe recommended upgrade requires Adrien's approval."
+    )
+    assert "Memory ID" not in output
+    assert "Private recalled memory" not in output


### PR DESCRIPTION
Prevents recalled memory-record dumps from appearing in user-facing GARVIS responses while preserving normal research answers. Adds a regression test. Ruff passed and 11 focused tests passed.