### PR TITLE
Fix Option B directory listing timeout

### DIFF
--- a/src/garvis/capability_runtime.py
+++ b/src/garvis/capability_runtime.py
@@ -154,10 +154,13 @@ class CapabilityAwareRuntime:
         )
         try:
             report = execute_local_access(request, self.local_runtime.repository_root)
-            answer = self.local_runtime.respond(
-                request.original_request,
-                workspace_context=report.render_context(),
-            )
+            if request.operation == "list":
+                answer = f"Read-only top-level listing for {report.target_path}:\n{report.content}"
+            else:
+                answer = self.local_runtime.respond(
+                    request.original_request,
+                    workspace_context=report.render_context(),
+                )
         except LocalAccessError as exc:
             self.local_access_store.audit(
                 "local_access_failed",

--- a/src/garvis/local_file_access.py
+++ b/src/garvis/local_file_access.py
@@ -291,6 +291,46 @@ def _iter_safe_files(
         yield path
 
 
+def _list_safe_entries(
+    directory: Path,
+    roots: tuple[Path, ...],
+    *,
+    limit: int = 150,
+    max_context_chars: int = 5_000,
+) -> str:
+    # Return a bounded top-level listing without opening file contents.
+    entries: list[str] = []
+    used = 0
+    try:
+        candidates = sorted(directory.iterdir(), key=lambda item: item.name.casefold())
+    except OSError as exc:
+        raise LocalAccessError(f"Could not list target directory: {exc}") from exc
+
+    for path in candidates:
+        if len(entries) >= limit:
+            break
+        if path.is_symlink() or _is_sensitive(path):
+            continue
+        try:
+            resolved = path.resolve()
+        except OSError:
+            continue
+        if not _inside_allowed(resolved, roots):
+            continue
+        if path.is_dir():
+            rendered = f"{path.name}/"
+        elif path.is_file():
+            rendered = path.name
+        else:
+            continue
+        if used + len(rendered) + 1 > max_context_chars:
+            break
+        entries.append(rendered)
+        used += len(rendered) + 1
+
+    return "\n".join(entries) if entries else "No visible, non-sensitive entries found."
+
+
 def execute_local_access(
     request: LocalAccessRequest,
     repository_root: Path,
@@ -307,6 +347,14 @@ def execute_local_access(
 
     if not target.is_dir():
         raise LocalAccessError("Target is neither a regular file nor a directory")
+
+    if request.operation == "list":
+        content = _list_safe_entries(
+            target,
+            approved_roots,
+            max_context_chars=max_context_chars,
+        )
+        return LocalAccessReport(str(target), "list", content)
 
     if request.operation == "search":
         query = request.search_query.casefold()
@@ -332,15 +380,11 @@ def execute_local_access(
         content = "\n".join(matches) if matches else "No matching text found."
         return LocalAccessReport(str(target), "search", content)
 
-    entries: list[str] = []
-    used = 0
-    for path in _iter_safe_files(target, approved_roots, limit=150):
-        rendered = path.relative_to(target).as_posix()
-        if used + len(rendered) + 1 > max_context_chars:
-            break
-        entries.append(rendered)
-        used += len(rendered) + 1
-    content = "\n".join(entries) if entries else "No readable, non-sensitive text files found."
+    content = _list_safe_entries(
+        target,
+        approved_roots,
+        max_context_chars=max_context_chars,
+    )
     return LocalAccessReport(str(target), "list", content)
 
 

--- a/tests/garvis/test_capability_runtime.py
+++ b/tests/garvis/test_capability_runtime.py
@@ -106,3 +106,22 @@ def test_local_file_denial_reads_nothing(tmp_path: Path) -> None:
     assert runtime.respond("n") == "Local file access denied. No files were read."
     assert local.calls == []
     runtime.close()
+
+
+def test_directory_list_returns_without_calling_model(tmp_path: Path) -> None:
+    (tmp_path / "alpha.txt").write_text("do not open me", encoding="utf-8")
+    (tmp_path / "folder").mkdir()
+    local = FakeLocal(tmp_path)
+    research = FakeResearcher()
+    runtime = make_runtime(tmp_path, local, research)
+
+    assert "Approve? [Y/N]" in runtime.respond(f'List files in "{tmp_path}"')
+    result = runtime.respond("y")
+
+    assert "Read-only top-level listing" in result
+    assert "alpha.txt" in result
+    assert "folder/" in result
+    assert "do not open me" not in result
+    assert local.calls == []
+    assert research.queries == []
+    runtime.close()

--- a/tests/garvis/test_local_file_access.py
+++ b/tests/garvis/test_local_file_access.py
@@ -84,3 +84,34 @@ def test_outside_allowed_roots_is_blocked(tmp_path: Path) -> None:
     )
     with pytest.raises(LocalAccessError, match="outside the approved"):
         execute_local_access(request, tmp_path, roots=(tmp_path.resolve(),))
+
+
+def test_directory_list_is_top_level_and_does_not_open_files(tmp_path: Path) -> None:
+    visible = tmp_path / "visible.txt"
+    visible.write_text("content must not be returned", encoding="utf-8")
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    (nested / "deep.txt").write_text("deep content", encoding="utf-8")
+    secret = tmp_path / ".secrets"
+    secret.mkdir()
+    (secret / "hidden.txt").write_text("hidden", encoding="utf-8")
+
+    now = datetime.now(timezone.utc)
+    request = LocalAccessRequest(
+        "id",
+        "default",
+        "list directory",
+        str(tmp_path),
+        "list",
+        "",
+        LocalAccessState.APPROVED,
+        now,
+        now,
+    )
+    report = execute_local_access(request, tmp_path, roots=(tmp_path.resolve(),))
+
+    assert "visible.txt" in report.content
+    assert "nested/" in report.content
+    assert "deep.txt" not in report.content
+    assert "content must not be returned" not in report.content
+    assert ".secrets" not in report.content


### PR DESCRIPTION
Makes directory listing top-level, bounded, read-only, and deterministic. GARVIS no longer invokes the local language model merely to return filenames, so approved listings complete quickly. No file contents are opened, secret exclusions remain enforced, internet behavior is unchanged, and focused tests, Ruff, and mypy pass.