### PR TITLE
Return deterministic local file search results

### DIFF
--- a/src/garvis/capability_runtime.py
+++ b/src/garvis/capability_runtime.py
@@ -156,6 +156,11 @@ class CapabilityAwareRuntime:
             report = execute_local_access(request, self.local_runtime.repository_root)
             if request.operation == "list":
                 answer = f"Read-only top-level listing for {report.target_path}:\n{report.content}"
+            elif request.operation == "search":
+                answer = (
+                    f"Read-only text matches for {request.search_query!r} "
+                    f"in {report.target_path}:\n{report.content}"
+                )
             else:
                 answer = self.local_runtime.respond(
                     request.original_request,

--- a/tests/garvis/test_capability_runtime.py
+++ b/tests/garvis/test_capability_runtime.py
@@ -125,3 +125,27 @@ def test_directory_list_returns_without_calling_model(tmp_path: Path) -> None:
     assert local.calls == []
     assert research.queries == []
     runtime.close()
+
+
+def test_file_search_returns_exact_matches_without_calling_model(tmp_path: Path) -> None:
+    source = tmp_path / "settings.py"
+    source.write_text(
+        'ROOTS = os.getenv("GARVIS_LOCAL_ACCESS_ROOTS", "")\n',
+        encoding="utf-8",
+    )
+    local = FakeLocal(tmp_path)
+    research = FakeResearcher()
+    runtime = make_runtime(tmp_path, local, research)
+
+    request = runtime.respond(f'Search files in "{tmp_path}" for GARVIS_LOCAL_ACCESS_ROOTS')
+    assert "Approve? [Y/N]" in request
+
+    result = runtime.respond("y")
+
+    assert "Read-only text matches" in result
+    assert "settings.py:1:" in result
+    assert "GARVIS_LOCAL_ACCESS_ROOTS" in result
+    assert "is set to" not in result
+    assert local.calls == []
+    assert research.queries == []
+    runtime.close()


### PR DESCRIPTION
Returns approved local text-search matches directly instead of sending them through the local language model. This prevents inference from being presented as exact file evidence. Search remains read-only, bounded, one-task approved, and subject to all existing secret exclusions. Focused Ruff, pytest, and mypy pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read-only file search with exact text-match results.
  * Search results include the matching file, line number, and context.
  * Local searches return directly without invoking AI models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->