### PR TITLE
Fix local GARVIS session routing

### DIFF
--- a/src/garvis/cli.py
+++ b/src/garvis/cli.py
@@ -116,12 +116,12 @@ def _run_local_lattice_cycle(args: argparse.Namespace) -> int:
     return 0
 
 
-def _build_local_runtime() -> CapabilityAwareRuntime:
+def _build_local_runtime(session_id: str = "default") -> CapabilityAwareRuntime:
     from .capability_runtime import CapabilityAwareRuntime
     from .local_language_runtime import LocalLanguageRuntime, LocalRuntimeConfig
 
     local = LocalLanguageRuntime(LocalRuntimeConfig.from_environment(Path.cwd()))
-    return CapabilityAwareRuntime(local)
+    return CapabilityAwareRuntime(local, session_id=session_id)
 
 
 def _configure_local_memory(args: argparse.Namespace) -> None:
@@ -158,7 +158,7 @@ def _run_local(args: argparse.Namespace) -> int:
     _configure_local_memory(args)
 
     try:
-        runtime = _build_local_runtime()
+        runtime = _build_local_runtime(args.session)
     except Exception as exc:
         print(f"GARVIS local configuration error: {exc}", file=sys.stderr)
         return 2

--- a/tests/garvis/test_cli.py
+++ b/tests/garvis/test_cli.py
@@ -50,7 +50,7 @@ def test_default_run_uses_local_runtime(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     runtime = FakeLocalRuntime()
-    monkeypatch.setattr(cli, "_build_local_runtime", lambda: runtime)
+    monkeypatch.setattr(cli, "_build_local_runtime", lambda session_id="default": runtime)
 
     args = cli.build_parser().parse_args(["hello"])
     result = asyncio.run(cli._run(args))
@@ -76,7 +76,7 @@ def test_local_one_shot_consumes_approval(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     runtime = FakeApprovalRuntime()
-    monkeypatch.setattr(cli, "_build_local_runtime", lambda: runtime)
+    monkeypatch.setattr(cli, "_build_local_runtime", lambda session_id="default": runtime)
     monkeypatch.setattr("builtins.input", lambda: "y")
 
     args = cli.build_parser().parse_args(["research", "current", "drywall", "prices"])


### PR DESCRIPTION
Passes the selected CLI session into CapabilityAwareRuntime. Rebases onto current main, which contains the ARC-3 lint and typecheck corrections for Actions run 29841581170.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Local interactive and non-interactive runs now consistently use the selected conversation session.
  * Session-specific context is preserved when initializing the local runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->