### PR TITLE
Route local GARVIS memory through selected session

### DIFF
--- a/src/garvis/cli.py
+++ b/src/garvis/cli.py
@@ -120,11 +120,12 @@ def _build_local_runtime(session_id: str = "default") -> CapabilityAwareRuntime:
     from .capability_runtime import CapabilityAwareRuntime
     from .local_language_runtime import LocalLanguageRuntime, LocalRuntimeConfig
 
+    normalized_session_id = session_id.strip() or "default"
     local = LocalLanguageRuntime(
         LocalRuntimeConfig.from_environment(Path.cwd()),
-        session_id=session_id,
+        session_id=normalized_session_id,
     )
-    return CapabilityAwareRuntime(local, session_id=session_id)
+    return CapabilityAwareRuntime(local, session_id=normalized_session_id)
 
 
 def _configure_local_memory(args: argparse.Namespace) -> None:

--- a/src/garvis/cli.py
+++ b/src/garvis/cli.py
@@ -120,7 +120,10 @@ def _build_local_runtime(session_id: str = "default") -> CapabilityAwareRuntime:
     from .capability_runtime import CapabilityAwareRuntime
     from .local_language_runtime import LocalLanguageRuntime, LocalRuntimeConfig
 
-    local = LocalLanguageRuntime(LocalRuntimeConfig.from_environment(Path.cwd()))
+    local = LocalLanguageRuntime(
+        LocalRuntimeConfig.from_environment(Path.cwd()),
+        session_id=session_id,
+    )
     return CapabilityAwareRuntime(local, session_id=session_id)
 
 

--- a/src/garvis/local_language_runtime.py
+++ b/src/garvis/local_language_runtime.py
@@ -271,10 +271,13 @@ class LocalLanguageRuntime:
         self,
         config: LocalRuntimeConfig,
         repository_root: Path | None = None,
+        *,
+        session_id: str = "default",
     ) -> None:
         config.validate()
         self.config = config
         self.repository_root = (repository_root or Path.cwd()).resolve()
+        self.session_id = session_id.strip() or "default"
 
     def respond(
         self,
@@ -306,12 +309,16 @@ class LocalLanguageRuntime:
                 memory_store = MemoryStore.from_environment()
                 ensure_core_memories(memory_store)
                 core_context = render_core_context(memory_store)
-                recalled_context = memory_store.render_context(envelope.request)
+                recalled_context = memory_store.render_context(
+                    envelope.request,
+                    session_id=self.session_id,
+                )
                 memory_context = "\n".join(
                     part for part in (core_context, recalled_context) if part
                 )
                 memory_store.remember(
                     envelope.request,
+                    session_id=self.session_id,
                     kind=MemoryKind.EPISODIC,
                     evidence_status=EvidenceStatus(envelope.evidence_status),
                     source="adrien_user_input",
@@ -379,6 +386,7 @@ class LocalLanguageRuntime:
 
                 memory_store.remember(
                     output[: memory_store.policy.model_output_max_chars],
+                    session_id=self.session_id,
                     kind=MemoryKind.EPISODIC,
                     evidence_status=EvidenceStatus.MODEL_GENERATED,
                     source="local_model_output",

--- a/tests/garvis/test_cli.py
+++ b/tests/garvis/test_cli.py
@@ -91,3 +91,50 @@ def test_local_one_shot_consumes_approval(
     output = capsys.readouterr().out
     assert "Approve? [Y/N]" in output
     assert output.rstrip().endswith("Approved research answer.")
+
+@pytest.mark.parametrize(
+    ("raw_session_id", "expected_session_id"),
+    [
+        ("   ", "default"),
+        (" adrien-main ", "adrien-main"),
+    ],
+)
+def test_build_local_runtime_normalizes_shared_session_id(
+    monkeypatch: pytest.MonkeyPatch,
+    raw_session_id: str,
+    expected_session_id: str,
+) -> None:
+    captured: dict[str, str] = {}
+
+    class FakeLocalRuntimeConfig:
+        @staticmethod
+        def from_environment(_repository_root: object) -> object:
+            return object()
+
+    class FakeLocalLanguageRuntime:
+        def __init__(self, _config: object, *, session_id: str) -> None:
+            captured["local"] = session_id
+
+    class FakeCapabilityAwareRuntime:
+        def __init__(self, _local_runtime: object, *, session_id: str) -> None:
+            captured["capability"] = session_id
+
+    monkeypatch.setattr(
+        "garvis.local_language_runtime.LocalRuntimeConfig",
+        FakeLocalRuntimeConfig,
+    )
+    monkeypatch.setattr(
+        "garvis.local_language_runtime.LocalLanguageRuntime",
+        FakeLocalLanguageRuntime,
+    )
+    monkeypatch.setattr(
+        "garvis.capability_runtime.CapabilityAwareRuntime",
+        FakeCapabilityAwareRuntime,
+    )
+
+    cli._build_local_runtime(raw_session_id)
+
+    assert captured == {
+        "local": expected_session_id,
+        "capability": expected_session_id,
+    }


### PR DESCRIPTION
Passes the selected CLI session into LocalLanguageRuntime so recall, user input, and model output are stored under adrien-main instead of default. Focused tests: 10 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Local conversations now maintain separate session-specific memory, helping responses stay relevant to the active conversation.
  - User inputs, generated responses, and recalled context are scoped to the current session.
  - Session identifiers are now trimmed and default to a standard value when blank or whitespace-only.
- **Tests**
  - Added coverage to verify session normalization is applied consistently across the local and capability-aware runtimes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->