### PR TITLE
feat(thanos): add standing autonomous upgrade mode

### DIFF
--- a/src/garvis/thanos_cli.py
+++ b/src/garvis/thanos_cli.py
@@ -1,0 +1,195 @@
+"""``garvis thanos`` command-line interface.
+
+Project and conceptual architecture: Adrien D. Thomas (ProCityHub/GARVIS).
+
+Every status line this module prints is derived from persisted state. A
+subsystem that has not been implemented reports NOT_IMPLEMENTED and exits
+non-zero rather than printing ENABLED, so the status block can never claim
+a capability that has no code behind it.
+
+Python 3.9 compatible. Termux-safe default store under ``~/.garvis``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from collections.abc import Sequence
+from pathlib import Path
+
+from garvis.thanos_mode import (
+    ThanosAuthorizationStore,
+    ThanosError,
+    create_authorization,
+    pause_authorization,
+    render_status,
+    resume_authorization,
+    revoke_authorization,
+)
+from garvis.upgrade_cycle import CycleStore
+
+__all__ = ["build_parser", "main"]
+
+TARGET_VERSION = "2.0.0-beta.1"
+PROJECT_DESIGNATION = "GARVIS_VERSION_2_FULL_AGI_BETA"
+
+#: Subsystems required by the THANOS directive that are not yet implemented.
+#: Listed explicitly so ``status`` reports absence instead of silence.
+_UNIMPLEMENTED = (
+    "INTERNET_RESEARCH_WIRING",
+    "UPGRADE_WORKSPACE",
+    "REPAIR_ENGINE",
+    "GITHUB_CI_MONITOR",
+    "RUNTIME_HEALTH_CHECK",
+    "ROLLBACK",
+    "CAPABILITY_REGISTRY",
+)
+
+
+def default_store_root() -> Path:
+    """Return the state directory, honouring ``GARVIS_HOME``."""
+
+    override = os.environ.get("GARVIS_HOME")
+    if override:
+        return Path(override)
+    return Path.home() / ".garvis"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="garvis thanos",
+        description="THANOS MODE standing authorization for GARVIS self-upgrade.",
+    )
+    parser.add_argument(
+        "--store-root",
+        default=None,
+        help="Directory holding THANOS state (default: ~/.garvis).",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("enable", help="Create the standing authorization.")
+    sub.add_parser("status", help="Print the current THANOS status block.")
+    sub.add_parser("pause", help="Suspend autonomous work without revoking.")
+    sub.add_parser("resume", help="Resume a paused standing authorization.")
+    sub.add_parser("history", help="Print the authorization chain.")
+    sub.add_parser("run", help="Run one autonomous upgrade cycle.")
+    sub.add_parser("health", help="Report runtime health.")
+
+    revoke = sub.add_parser("revoke", help="Permanently revoke THANOS MODE.")
+    revoke.add_argument("--reason", required=True, help="Why the mode is revoked.")
+
+    return parser
+
+
+def _paths(root: Path) -> tuple[Path, Path]:
+    return root / "thanos.json", root / "cycles.json"
+
+
+def _load(store: ThanosAuthorizationStore):
+    try:
+        return store.load()
+    except ThanosError as error:
+        print(f"THANOS_STATE=TAMPERED\nERROR={error}")
+        return None
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    root = Path(args.store_root) if args.store_root else default_store_root()
+    auth_path, cycle_path = _paths(root)
+    store = ThanosAuthorizationStore(auth_path)
+
+    if args.command == "enable":
+        try:
+            existing = store.load()
+        except ThanosError as error:
+            print(f"REFUSED=TAMPERED_STORE\nERROR={error}")
+            return 2
+        if existing is not None and not existing.is_revoked:
+            print("REFUSED=ALREADY_ENABLED")
+            print(render_status(existing, target_version=TARGET_VERSION))
+            return 1
+        if existing is not None and existing.is_revoked:
+            # The revoked grant stays in the chain as audit history; the owner
+            # issues a new one. Revocation retires an authorization, it does
+            # not lock the owner out of the system.
+            print(f"SUPERSEDING_REVOKED_AUTHORIZATION={existing.authorization_id}")
+            print(f"PREVIOUS_REVOCATION_REASON={existing.revocation_reason}")
+        previous = existing.record_hash if existing is not None else "0" * 64
+        record = store.append(create_authorization(previous_record_hash=previous))
+        print(render_status(record, target_version=TARGET_VERSION))
+        print(f"PROJECT_DESIGNATION={PROJECT_DESIGNATION}")
+        print("# The lines above state what is AUTHORIZED, not what is built.")
+        for subsystem in _UNIMPLEMENTED:
+            print(f"{subsystem}=NOT_IMPLEMENTED")
+        return 0
+
+    if args.command == "status":
+        record = _load(store)
+        print(render_status(record, target_version=TARGET_VERSION))
+        print(f"PROJECT_DESIGNATION={PROJECT_DESIGNATION}")
+        active = CycleStore(cycle_path).resume()
+        if active is None:
+            print("ACTIVE_CYCLE=NONE")
+        else:
+            print(f"ACTIVE_CYCLE={active.cycle_id}")
+            print(f"ACTIVE_CYCLE_STATE={active.state.value}")
+            if active.blocker:
+                print(f"ACTIVE_CYCLE_BLOCKER={active.blocker}")
+        for subsystem in _UNIMPLEMENTED:
+            print(f"{subsystem}=NOT_IMPLEMENTED")
+        return 0
+
+    if args.command in {"pause", "resume"}:
+        record = _load(store)
+        if record is None:
+            print("REFUSED=NO_AUTHORIZATION")
+            return 1
+        try:
+            mutate = pause_authorization if args.command == "pause" else resume_authorization
+            print(render_status(store.append(mutate(record)), target_version=TARGET_VERSION))
+        except ThanosError as error:
+            print(f"REFUSED={error}")
+            return 1
+        return 0
+
+    if args.command == "revoke":
+        record = _load(store)
+        if record is None:
+            print("REFUSED=NO_AUTHORIZATION")
+            return 1
+        try:
+            revoked = store.append(revoke_authorization(record, reason=args.reason))
+        except ThanosError as error:
+            print(f"REFUSED={error}")
+            return 1
+        print(render_status(revoked, target_version=TARGET_VERSION))
+        return 0
+
+    if args.command == "history":
+        try:
+            chain = store.history()
+        except ThanosError as error:
+            print(f"THANOS_STATE=TAMPERED\nERROR={error}")
+            return 2
+        if not chain:
+            print("AUTHORIZATION_CHAIN=EMPTY")
+            return 0
+        for index, record in enumerate(chain):
+            state = "REVOKED" if record.is_revoked else ("PAUSED" if record.paused else "ENABLED")
+            print(f"{index}\t{record.updated_at}\t{state}\t{record.record_hash[:16]}")
+        print(f"CHAIN_LENGTH={len(chain)}")
+        return 0
+
+    if args.command in {"run", "health"}:
+        subsystem = "AUTONOMOUS_REPAIR_LOOP" if args.command == "run" else "RUNTIME_HEALTH_CHECK"
+        print(f"{subsystem}=NOT_IMPLEMENTED")
+        print("REASON=required modules are not present in this build")
+        print("MISSING=" + ",".join(_UNIMPLEMENTED))
+        return 3
+
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/garvis/thanos_mode.py
+++ b/src/garvis/thanos_mode.py
@@ -1,0 +1,630 @@
+"""THANOS MODE standing authorization for GARVIS self-maintenance.
+
+Project and conceptual architecture: Adrien D. Thomas (ProCityHub/GARVIS).
+
+THANOS MODE is a persistent, revocable, repository-scoped standing
+authorization. While it is enabled, GARVIS may run its own maintenance
+lifecycle -- research, diagnose, patch, test, commit, push, open and repair
+pull requests -- without emitting a per-stage approval prompt.
+
+An active authorization permits autonomous squash-merge of ordinary GARVIS
+changes once every merge precondition in ``MergePreconditions`` holds.
+
+Governance paths (``PROTECTED_PATHS``) are the single exception. A cycle may
+freely research, patch, test and open pull requests against them, but it
+cannot self-certify the merge, because the validation profile for those
+files -- the test suite, the CI workflows, this module -- is exactly what
+such a change edits. Enforcement lives in GitHub branch protection and
+CODEOWNERS, outside the runtime GARVIS can rewrite.
+
+Python 3.9 compatible: no ``datetime.UTC``, no ``slots=True`` dataclasses,
+no 3.10-only union syntax at runtime.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, replace
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from garvis.stage_gate import (
+    canonical_json,
+    new_identifier,
+    parse_utc_iso,
+    sha256_payload,
+    utc_now_iso,
+)
+
+__all__ = [
+    "AUTHORIZATION_VERSION",
+    "DEFAULT_ALLOWED_ACTIONS",
+    "OWNER",
+    "PROTECTED_PATHS",
+    "REPOSITORY",
+    "RUNTIME_SCOPE",
+    "ThanosAction",
+    "ThanosAuthorization",
+    "ThanosAuthorizationStore",
+    "ThanosError",
+    "ThanosNotEnabledError",
+    "ThanosPausedError",
+    "ThanosRevokedError",
+    "ThanosScopeError",
+    "ThanosTamperError",
+    "MergeDecision",
+    "MergePreconditions",
+    "create_authorization",
+    "evaluate_merge_gate",
+    "is_protected_path",
+    "pause_authorization",
+    "permits",
+    "render_status",
+    "resume_authorization",
+    "revoke_authorization",
+]
+
+
+OWNER = "Adrien D. Thomas"
+REPOSITORY = "ProCityHub/GARVIS"
+RUNTIME_SCOPE = "garvis-runtime"
+AUTHORITY = "autonomous-self-upgrade"
+AUTHORIZATION_VERSION = 1
+GENESIS_HASH = "0" * 64
+
+
+class ThanosError(RuntimeError):
+    """Base error for THANOS MODE."""
+
+
+class ThanosNotEnabledError(ThanosError):
+    """Raised when protected work is attempted without an enabled grant."""
+
+
+class ThanosPausedError(ThanosError):
+    """Raised when the standing authorization is paused."""
+
+
+class ThanosRevokedError(ThanosError):
+    """Raised when the standing authorization has been revoked."""
+
+
+class ThanosScopeError(ThanosError):
+    """Raised when an action falls outside the declared scope."""
+
+
+class ThanosTamperError(ThanosError):
+    """Raised when the persisted authorization chain fails verification."""
+
+
+class ThanosAction(str, Enum):
+    """Actions a THANOS cycle may perform without a per-stage prompt."""
+
+    RESEARCH = "research"
+    INSPECT = "inspect"
+    PLAN = "plan"
+    EDIT = "edit"
+    CREATE = "create"
+    REFACTOR = "refactor"
+    DEPENDENCY_UPDATE = "dependency-update"
+    TEST = "test"
+    SECURITY_REVIEW = "security-review"
+    PACKAGE = "package"
+    COMMIT = "commit"
+    PUSH = "push"
+    CREATE_PULL_REQUEST = "create-pull-request"
+    UPDATE_PULL_REQUEST = "update-pull-request"
+    MONITOR_CI = "monitor-ci"
+    REPAIR_CI = "repair-ci"
+    REQUEST_MERGE = "request-merge"
+    RESTART = "restart"
+    ROLLBACK = "rollback"
+    CONTINUE_UPGRADING = "continue-upgrading"
+
+    MERGE = "merge"
+
+
+#: The full standing grant. MERGE is included: an active authorization
+#: permits autonomous squash-merge of ordinary GARVIS changes.
+DEFAULT_ALLOWED_ACTIONS = tuple(ThanosAction)
+
+#: Paths whose modification must not be merged by an autonomous cycle.
+#: The authoritative enforcement is GitHub branch protection + CODEOWNERS;
+#: this tuple is defense in depth on the local side.
+PROTECTED_PATHS = (
+    ".github/CODEOWNERS",
+    ".github/workflows/",
+    "src/garvis/thanos_mode.py",
+    "src/garvis/stage_gate.py",
+    "src/garvis/stage_gate_store.py",
+    "src/garvis/github_maintenance.py",
+    "src/garvis/upgrade_cycle.py",
+)
+
+
+def is_protected_path(relative_path: str) -> bool:
+    """Return True when ``relative_path`` is governance-protected."""
+
+    normalized = relative_path.replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    normalized = normalized.lstrip("/")
+    for protected in PROTECTED_PATHS:
+        if protected.endswith("/"):
+            if normalized.startswith(protected):
+                return True
+        elif normalized == protected:
+            return True
+    return False
+
+
+@dataclass(frozen=True)
+class ThanosAuthorization:
+    """A persistent, tamper-evident standing authorization record."""
+
+    authorization_id: str
+    owner: str
+    repository: str
+    runtime_scope: str
+    enabled: bool
+    paused: bool
+    created_at: str
+    updated_at: str
+    allowed_actions: tuple[str, ...]
+    authorization_version: int = AUTHORIZATION_VERSION
+    authority: str = AUTHORITY
+    revoked_at: str | None = None
+    revocation_reason: str | None = None
+    previous_record_hash: str = GENESIS_HASH
+    record_hash: str = ""
+
+    def identity_payload(self) -> dict[str, Any]:
+        """Return the hashed portion of the record."""
+
+        return {
+            "authorization_id": self.authorization_id,
+            "owner": self.owner,
+            "repository": self.repository,
+            "runtime_scope": self.runtime_scope,
+            "authority": self.authority,
+            "enabled": self.enabled,
+            "paused": self.paused,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "revoked_at": self.revoked_at,
+            "revocation_reason": self.revocation_reason,
+            "authorization_version": self.authorization_version,
+            "allowed_actions": list(self.allowed_actions),
+            "previous_record_hash": self.previous_record_hash,
+        }
+
+    def compute_hash(self) -> str:
+        """Return the deterministic hash of this record's identity payload."""
+
+        return sha256_payload(self.identity_payload())
+
+    def sealed(self) -> ThanosAuthorization:
+        """Return a copy carrying a freshly computed ``record_hash``."""
+
+        return replace(self, record_hash=self.compute_hash())
+
+    def verify(self) -> bool:
+        """Return True when ``record_hash`` matches the identity payload."""
+
+        return bool(self.record_hash) and self.record_hash == self.compute_hash()
+
+    @property
+    def is_revoked(self) -> bool:
+        return self.revoked_at is not None
+
+    @property
+    def is_active(self) -> bool:
+        """True when the grant currently permits autonomous work."""
+
+        return self.enabled and not self.paused and not self.is_revoked
+
+    def to_payload(self) -> dict[str, Any]:
+        payload = self.identity_payload()
+        payload["record_hash"] = self.record_hash
+        return payload
+
+    @classmethod
+    def from_payload(cls, payload: Mapping[str, Any]) -> ThanosAuthorization:
+        try:
+            return cls(
+                authorization_id=str(payload["authorization_id"]),
+                owner=str(payload["owner"]),
+                repository=str(payload["repository"]),
+                runtime_scope=str(payload["runtime_scope"]),
+                authority=str(payload.get("authority", AUTHORITY)),
+                enabled=bool(payload["enabled"]),
+                paused=bool(payload["paused"]),
+                created_at=str(payload["created_at"]),
+                updated_at=str(payload["updated_at"]),
+                revoked_at=(
+                    None if payload.get("revoked_at") is None else str(payload["revoked_at"])
+                ),
+                revocation_reason=(
+                    None
+                    if payload.get("revocation_reason") is None
+                    else str(payload["revocation_reason"])
+                ),
+                authorization_version=int(payload["authorization_version"]),
+                allowed_actions=tuple(str(a) for a in payload["allowed_actions"]),
+                previous_record_hash=str(payload["previous_record_hash"]),
+                record_hash=str(payload.get("record_hash", "")),
+            )
+        except (KeyError, TypeError, ValueError) as error:
+            raise ThanosTamperError("THANOS authorization payload is malformed") from error
+
+
+def create_authorization(
+    *,
+    owner: str = OWNER,
+    repository: str = REPOSITORY,
+    runtime_scope: str = RUNTIME_SCOPE,
+    allowed_actions: Sequence[ThanosAction] | None = None,
+    now: str | None = None,
+    previous_record_hash: str = GENESIS_HASH,
+) -> ThanosAuthorization:
+    """Create a new enabled standing authorization."""
+
+    actions = tuple(allowed_actions or DEFAULT_ALLOWED_ACTIONS)
+    timestamp = now or utc_now_iso()
+    parse_utc_iso(timestamp)
+    record = ThanosAuthorization(
+        authorization_id=new_identifier("thanos"),
+        owner=owner,
+        repository=repository,
+        runtime_scope=runtime_scope,
+        enabled=True,
+        paused=False,
+        created_at=timestamp,
+        updated_at=timestamp,
+        allowed_actions=tuple(a.value for a in actions),
+        previous_record_hash=previous_record_hash,
+    )
+    return record.sealed()
+
+
+def _amended(
+    authorization: ThanosAuthorization,
+    *,
+    now: str | None = None,
+    **changes: Any,
+) -> ThanosAuthorization:
+    timestamp = now or utc_now_iso()
+    parse_utc_iso(timestamp)
+    record = replace(
+        authorization,
+        updated_at=timestamp,
+        previous_record_hash=authorization.record_hash,
+        record_hash="",
+        **changes,
+    )
+    return record.sealed()
+
+
+def pause_authorization(
+    authorization: ThanosAuthorization, *, now: str | None = None
+) -> ThanosAuthorization:
+    """Pause autonomous work without revoking the standing grant."""
+
+    if authorization.is_revoked:
+        raise ThanosRevokedError("cannot pause a revoked authorization")
+    return _amended(authorization, paused=True, now=now)
+
+
+def resume_authorization(
+    authorization: ThanosAuthorization, *, now: str | None = None
+) -> ThanosAuthorization:
+    """Resume a paused standing grant."""
+
+    if authorization.is_revoked:
+        raise ThanosRevokedError("cannot resume a revoked authorization")
+    return _amended(authorization, paused=False, now=now)
+
+
+def revoke_authorization(
+    authorization: ThanosAuthorization,
+    *,
+    reason: str,
+    now: str | None = None,
+) -> ThanosAuthorization:
+    """Permanently revoke the standing grant."""
+
+    if not reason.strip():
+        raise ValueError("revocation reason is required")
+    timestamp = now or utc_now_iso()
+    return _amended(
+        authorization,
+        enabled=False,
+        paused=False,
+        revoked_at=timestamp,
+        revocation_reason=reason.strip(),
+        now=timestamp,
+    )
+
+
+def permits(
+    authorization: ThanosAuthorization,
+    action: ThanosAction | str,
+    *,
+    repository: str = REPOSITORY,
+    runtime_scope: str = RUNTIME_SCOPE,
+) -> None:
+    """Raise unless ``action`` is inside the standing authorization's scope.
+
+    The grant is never consumed: repeated calls with the same action succeed
+    for as long as the authorization stays active.
+    """
+
+    if not authorization.verify():
+        raise ThanosTamperError("THANOS authorization failed hash verification")
+    if authorization.is_revoked:
+        raise ThanosRevokedError(f"THANOS MODE was revoked: {authorization.revocation_reason}")
+    if not authorization.enabled:
+        raise ThanosNotEnabledError("THANOS MODE is not enabled")
+    if authorization.paused:
+        raise ThanosPausedError("THANOS MODE is paused")
+    if repository != authorization.repository:
+        raise ThanosScopeError(
+            f"repository {repository!r} is outside THANOS scope {authorization.repository!r}"
+        )
+    if runtime_scope != authorization.runtime_scope:
+        raise ThanosScopeError(
+            f"runtime scope {runtime_scope!r} is outside THANOS scope "
+            f"{authorization.runtime_scope!r}"
+        )
+
+    value = action.value if isinstance(action, ThanosAction) else str(action)
+    if value not in authorization.allowed_actions:
+        raise ThanosScopeError(f"action {value!r} is not authorized")
+
+
+class ThanosAuthorizationStore:
+    """Atomic, tamper-evident persistence for the standing authorization."""
+
+    def __init__(self, path: str | Path) -> None:
+        self._path = Path(path)
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def exists(self) -> bool:
+        return self._path.is_file()
+
+    def load(self) -> ThanosAuthorization | None:
+        """Load and verify the persisted chain head, or None when absent."""
+
+        if not self.exists():
+            return None
+        try:
+            raw = json.loads(self._path.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as error:
+            raise ThanosTamperError("THANOS store is unreadable") from error
+        if not isinstance(raw, dict) or "chain" not in raw:
+            raise ThanosTamperError("THANOS store is malformed")
+        chain = raw["chain"]
+        if not isinstance(chain, list) or not chain:
+            raise ThanosTamperError("THANOS store contains no records")
+
+        previous = GENESIS_HASH
+        record: ThanosAuthorization | None = None
+        for entry in chain:
+            if not isinstance(entry, dict):
+                raise ThanosTamperError("THANOS chain entry is malformed")
+            record = ThanosAuthorization.from_payload(entry)
+            if not record.verify():
+                raise ThanosTamperError(
+                    f"THANOS record {record.authorization_id} failed hash verification"
+                )
+            if record.previous_record_hash != previous:
+                raise ThanosTamperError("THANOS chain linkage is broken")
+            previous = record.record_hash
+        return record
+
+    def history(self) -> tuple[ThanosAuthorization, ...]:
+        """Return the verified chain, oldest first."""
+
+        if not self.exists():
+            return ()
+        self.load()  # verification pass
+        raw = json.loads(self._path.read_text(encoding="utf-8"))
+        return tuple(ThanosAuthorization.from_payload(entry) for entry in raw["chain"])
+
+    def append(self, authorization: ThanosAuthorization) -> ThanosAuthorization:
+        """Atomically append a verified record to the chain."""
+
+        if not authorization.verify():
+            raise ThanosTamperError("refusing to persist an unsealed record")
+        existing = self.history()
+        if existing:
+            head = existing[-1]
+            if authorization.previous_record_hash != head.record_hash:
+                raise ThanosTamperError("new record does not link to the current chain head")
+        elif authorization.previous_record_hash != GENESIS_HASH:
+            raise ThanosTamperError("first record must link to the genesis hash")
+
+        chain = [record.to_payload() for record in existing]
+        chain.append(authorization.to_payload())
+        self._atomic_write({"version": AUTHORIZATION_VERSION, "chain": chain})
+        return authorization
+
+    def _atomic_write(self, payload: Mapping[str, Any]) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        handle, temporary = tempfile.mkstemp(
+            dir=str(self._path.parent), prefix=".thanos-", suffix=".tmp"
+        )
+        try:
+            with os.fdopen(handle, "w", encoding="utf-8") as stream:
+                stream.write(canonical_json(payload))
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.replace(temporary, str(self._path))
+        except BaseException:
+            if os.path.exists(temporary):
+                os.unlink(temporary)
+            raise
+
+
+def render_status(
+    authorization: ThanosAuthorization | None,
+    *,
+    target_version: str = "2.0.0-beta.1",
+) -> str:
+    """Render the THANOS status block."""
+
+    if authorization is None:
+        return "\n".join(
+            (
+                "THANOS_MODE=DISABLED",
+                f"OWNER={OWNER}",
+                f"REPOSITORY={REPOSITORY}",
+                "STANDING_AUTHORITY=ABSENT",
+                f"TARGET_VERSION={target_version}",
+            )
+        )
+
+    if authorization.is_revoked:
+        state = "REVOKED"
+        authority = "REVOKED"
+    elif authorization.paused:
+        state = "PAUSED"
+        authority = "VALID"
+    elif authorization.enabled:
+        state = "ENABLED"
+        authority = "VALID"
+    else:
+        state = "DISABLED"
+        authority = "INACTIVE"
+
+    active = "ENABLED" if authorization.is_active else "SUSPENDED"
+    lines = [
+        f"THANOS_MODE={state}",
+        f"OWNER={authorization.owner}",
+        f"REPOSITORY={authorization.repository}",
+        f"RUNTIME_SCOPE={authorization.runtime_scope}",
+        f"STANDING_AUTHORITY={authority}",
+        "PERSISTENT_UNTIL_REVOKED=YES",
+        f"INTERNET_RESEARCH={active}",
+        f"AUTONOMOUS_SELF_REPAIR={active}",
+        f"AUTONOMOUS_COMMIT={active}",
+        f"AUTONOMOUS_PUSH={active}",
+        f"AUTONOMOUS_PR={active}",
+        f"AUTONOMOUS_CI_REPAIR={active}",
+        f"AUTONOMOUS_MERGE_WHEN_GREEN={active}",
+        f"AUTONOMOUS_RESTART={active}",
+        f"AUTONOMOUS_ROLLBACK={active}",
+        "PER_STAGE_APPROVAL_PROMPTS=0",
+        "OWNER_MERGE_CHECKPOINTS_PER_CYCLE=0",
+        f"AUTHORIZATION_ID={authorization.authorization_id}",
+        f"RECORD_HASH={authorization.record_hash[:16]}",
+        f"TARGET_VERSION={target_version}",
+    ]
+    if authorization.is_revoked:
+        lines.append(f"REVOKED_AT={authorization.revoked_at}")
+        lines.append(f"REVOCATION_REASON={authorization.revocation_reason}")
+    return "\n".join(lines)
+
+
+def protected_paths_in(paths: Iterable[str]) -> tuple[str, ...]:
+    """Return the governance-protected entries within ``paths``."""
+
+    return tuple(path for path in paths if is_protected_path(path))
+
+
+# --------------------------------------------------------------------------
+# Autonomous merge gate
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MergePreconditions:
+    """Observed facts a cycle must present before an autonomous merge."""
+
+    repository: str
+    changed_paths: tuple[str, ...]
+    expected_head_sha: str
+    actual_head_sha: str
+    required_checks_complete: bool
+    required_checks_passed: bool
+    tested_artifact_sha: str
+    proposed_artifact_sha: str
+    base_sha_at_test_time: str
+    base_sha_now: str
+    secrets_detected: bool = False
+    rollback_available: bool = True
+
+
+@dataclass(frozen=True)
+class MergeDecision:
+    """Result of evaluating the autonomous merge gate."""
+
+    allowed: bool
+    blocking_reasons: tuple[str, ...]
+    protected_paths: tuple[str, ...]
+
+    @property
+    def requires_owner_review(self) -> bool:
+        return bool(self.protected_paths)
+
+
+def evaluate_merge_gate(
+    authorization: ThanosAuthorization,
+    preconditions: MergePreconditions,
+    *,
+    runtime_scope: str = RUNTIME_SCOPE,
+) -> MergeDecision:
+    """Decide whether a cycle may squash-merge its own pull request.
+
+    Autonomous merge is permitted when the standing authorization is active
+    and every precondition holds. It is withheld when the change touches a
+    governance path, because those files define the validation profile that
+    would be certifying the change.
+    """
+
+    reasons: list[str] = []
+
+    try:
+        permits(
+            authorization,
+            ThanosAction.MERGE,
+            repository=preconditions.repository,
+            runtime_scope=runtime_scope,
+        )
+    except ThanosError as error:
+        reasons.append(str(error))
+
+    if preconditions.expected_head_sha != preconditions.actual_head_sha:
+        reasons.append("pull-request head moved since the candidate was tested")
+    if not preconditions.required_checks_complete:
+        reasons.append("required checks have not completed")
+    if not preconditions.required_checks_passed:
+        reasons.append("required checks did not pass")
+    if preconditions.tested_artifact_sha != preconditions.proposed_artifact_sha:
+        reasons.append("tested artifact does not match the proposed artifact")
+    if preconditions.base_sha_at_test_time != preconditions.base_sha_now:
+        reasons.append("base branch advanced; unrelated work would be overwritten")
+    if preconditions.secrets_detected:
+        reasons.append("secret material detected in the change")
+    if not preconditions.rollback_available:
+        reasons.append("no last-known-good state is available for rollback")
+
+    protected = protected_paths_in(preconditions.changed_paths)
+    if protected:
+        reasons.append(
+            "change touches governance paths that define its own validation "
+            "profile: " + ", ".join(protected)
+        )
+
+    return MergeDecision(
+        allowed=not reasons,
+        blocking_reasons=tuple(reasons),
+        protected_paths=protected,
+    )

--- a/src/garvis/upgrade_cycle.py
+++ b/src/garvis/upgrade_cycle.py
@@ -1,0 +1,519 @@
+"""Durable autonomous upgrade-cycle state machine for GARVIS THANOS MODE.
+
+Project and conceptual architecture: Adrien D. Thomas (ProCityHub/GARVIS).
+
+A cycle is a persistent record of one self-maintenance attempt. Every state
+transition is appended to durable storage before it takes effect, so a cycle
+interrupted by Android suspension, network loss, or process termination
+resumes from its last recorded state rather than restarting.
+
+Only one cycle may hold the modification lock at a time.
+
+Python 3.9 compatible. Termux-safe: no fcntl, no daemon threads, atomic
+``os.replace`` writes, and a stale-lock reaper based on process liveness.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import tempfile
+from dataclasses import dataclass, field, replace
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from garvis.stage_gate import canonical_json, new_identifier, utc_now_iso
+from garvis.thanos_mode import (
+    MergeDecision,
+    ThanosAction,
+    ThanosAuthorization,
+    ThanosError,
+    permits,
+)
+
+__all__ = [
+    "CycleLock",
+    "CycleLockError",
+    "CycleState",
+    "CycleStore",
+    "CycleTransitionError",
+    "TERMINAL_STATES",
+    "UpgradeCycle",
+    "advance",
+    "record_merge_decision",
+    "transition_is_legal",
+]
+
+
+class CycleState(str, Enum):
+    """States of one autonomous upgrade cycle."""
+
+    IDLE = "IDLE"
+    OBSERVING = "OBSERVING"
+    RESEARCHING = "RESEARCHING"
+    DIAGNOSING = "DIAGNOSING"
+    SPECIFYING = "SPECIFYING"
+    PLANNING = "PLANNING"
+    PREPARING_WORKSPACE = "PREPARING_WORKSPACE"
+    PATCHING = "PATCHING"
+    FORMATTING = "FORMATTING"
+    LINTING = "LINTING"
+    TYPE_CHECKING = "TYPE_CHECKING"
+    TESTING = "TESTING"
+    SECURITY_REVIEWING = "SECURITY_REVIEWING"
+    PACKAGING = "PACKAGING"
+    COMMITTING = "COMMITTING"
+    PUSHING = "PUSHING"
+    OPENING_PR = "OPENING_PR"
+    WAITING_FOR_CI = "WAITING_FOR_CI"
+    REPAIRING_CI = "REPAIRING_CI"
+    MERGING = "MERGING"
+    SYNCHRONIZING = "SYNCHRONIZING"
+    RESTARTING = "RESTARTING"
+    HEALTH_CHECKING = "HEALTH_CHECKING"
+    PROMOTING = "PROMOTING"
+    ROLLING_BACK = "ROLLING_BACK"
+    COMPLETED = "COMPLETED"
+    BLOCKED = "BLOCKED"
+    FAILED = "FAILED"
+    PAUSED = "PAUSED"
+    REVOKED = "REVOKED"
+
+
+TERMINAL_STATES = frozenset(
+    {
+        CycleState.COMPLETED,
+        CycleState.FAILED,
+        CycleState.REVOKED,
+    }
+)
+
+#: States a cycle may enter from anywhere: owner control and hard stops.
+_UNIVERSAL = frozenset(
+    {
+        CycleState.PAUSED,
+        CycleState.REVOKED,
+        CycleState.BLOCKED,
+        CycleState.FAILED,
+    }
+)
+
+_PIPELINE = (
+    CycleState.IDLE,
+    CycleState.OBSERVING,
+    CycleState.RESEARCHING,
+    CycleState.DIAGNOSING,
+    CycleState.SPECIFYING,
+    CycleState.PLANNING,
+    CycleState.PREPARING_WORKSPACE,
+    CycleState.PATCHING,
+    CycleState.FORMATTING,
+    CycleState.LINTING,
+    CycleState.TYPE_CHECKING,
+    CycleState.TESTING,
+    CycleState.SECURITY_REVIEWING,
+    CycleState.PACKAGING,
+    CycleState.COMMITTING,
+    CycleState.PUSHING,
+    CycleState.OPENING_PR,
+    CycleState.WAITING_FOR_CI,
+    CycleState.MERGING,
+    CycleState.SYNCHRONIZING,
+    CycleState.RESTARTING,
+    CycleState.HEALTH_CHECKING,
+    CycleState.PROMOTING,
+    CycleState.COMPLETED,
+)
+
+
+def _build_transitions() -> dict:
+    table: dict = {}
+    for index, state in enumerate(_PIPELINE):
+        allowed = set(_UNIVERSAL)
+        if index + 1 < len(_PIPELINE):
+            allowed.add(_PIPELINE[index + 1])
+        table[state] = allowed
+
+    # Validation failures fall back to PATCHING for a bounded repair.
+    for state in (
+        CycleState.FORMATTING,
+        CycleState.LINTING,
+        CycleState.TYPE_CHECKING,
+        CycleState.TESTING,
+        CycleState.SECURITY_REVIEWING,
+        CycleState.PACKAGING,
+    ):
+        table[state].add(CycleState.PATCHING)
+
+    table[CycleState.WAITING_FOR_CI].add(CycleState.REPAIRING_CI)
+    table[CycleState.REPAIRING_CI] = set(_UNIVERSAL) | {
+        CycleState.PATCHING,
+        CycleState.PUSHING,
+        CycleState.WAITING_FOR_CI,
+    }
+    table[CycleState.HEALTH_CHECKING].add(CycleState.ROLLING_BACK)
+    table[CycleState.PROMOTING].add(CycleState.ROLLING_BACK)
+    table[CycleState.ROLLING_BACK] = set(_UNIVERSAL) | {
+        CycleState.COMPLETED,
+        CycleState.OBSERVING,
+    }
+    table[CycleState.PAUSED] = set(_UNIVERSAL) | set(_PIPELINE)
+    table[CycleState.BLOCKED] = set(_UNIVERSAL) | {CycleState.OBSERVING}
+    for terminal in TERMINAL_STATES:
+        table[terminal] = set()
+    return table
+
+
+_TRANSITIONS = _build_transitions()
+
+
+class CycleTransitionError(RuntimeError):
+    """Raised on an illegal cycle-state transition."""
+
+
+def transition_is_legal(source: CycleState, destination: CycleState) -> bool:
+    """Return True when ``source -> destination`` is a permitted move."""
+
+    return destination in _TRANSITIONS.get(source, set())
+
+
+@dataclass(frozen=True)
+class CycleTransition:
+    """One recorded state change."""
+
+    source: str
+    destination: str
+    occurred_at: str
+    note: str = ""
+
+    def to_payload(self) -> dict:
+        return {
+            "source": self.source,
+            "destination": self.destination,
+            "occurred_at": self.occurred_at,
+            "note": self.note,
+        }
+
+
+@dataclass(frozen=True)
+class UpgradeCycle:
+    """Durable record of one autonomous upgrade attempt."""
+
+    cycle_id: str
+    objective: str
+    starting_commit: str
+    starting_version: str
+    state: CycleState = CycleState.IDLE
+    created_at: str = ""
+    updated_at: str = ""
+    transitions: tuple[CycleTransition, ...] = ()
+    changed_files: tuple[str, ...] = ()
+    evidence: dict = field(default_factory=dict)
+    pull_request_number: int | None = None
+    commit_sha: str | None = None
+    merge_sha: str | None = None
+    last_known_good: str | None = None
+    blocker: str | None = None
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.state in TERMINAL_STATES
+
+    def to_payload(self) -> dict:
+        return {
+            "cycle_id": self.cycle_id,
+            "objective": self.objective,
+            "starting_commit": self.starting_commit,
+            "starting_version": self.starting_version,
+            "state": self.state.value,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "transitions": [t.to_payload() for t in self.transitions],
+            "changed_files": list(self.changed_files),
+            "evidence": dict(self.evidence),
+            "pull_request_number": self.pull_request_number,
+            "commit_sha": self.commit_sha,
+            "merge_sha": self.merge_sha,
+            "last_known_good": self.last_known_good,
+            "blocker": self.blocker,
+        }
+
+    @classmethod
+    def from_payload(cls, payload: dict) -> UpgradeCycle:
+        return cls(
+            cycle_id=str(payload["cycle_id"]),
+            objective=str(payload["objective"]),
+            starting_commit=str(payload["starting_commit"]),
+            starting_version=str(payload["starting_version"]),
+            state=CycleState(payload["state"]),
+            created_at=str(payload.get("created_at", "")),
+            updated_at=str(payload.get("updated_at", "")),
+            transitions=tuple(
+                CycleTransition(
+                    source=str(t["source"]),
+                    destination=str(t["destination"]),
+                    occurred_at=str(t["occurred_at"]),
+                    note=str(t.get("note", "")),
+                )
+                for t in payload.get("transitions", [])
+            ),
+            changed_files=tuple(str(f) for f in payload.get("changed_files", [])),
+            evidence=dict(payload.get("evidence", {})),
+            pull_request_number=payload.get("pull_request_number"),
+            commit_sha=payload.get("commit_sha"),
+            merge_sha=payload.get("merge_sha"),
+            last_known_good=payload.get("last_known_good"),
+            blocker=payload.get("blocker"),
+        )
+
+
+def new_cycle(
+    *,
+    objective: str,
+    starting_commit: str,
+    starting_version: str,
+    last_known_good: str | None = None,
+    now: str | None = None,
+) -> UpgradeCycle:
+    """Create a fresh cycle in IDLE."""
+
+    timestamp = now or utc_now_iso()
+    return UpgradeCycle(
+        cycle_id=new_identifier("cycle"),
+        objective=objective,
+        starting_commit=starting_commit,
+        starting_version=starting_version,
+        created_at=timestamp,
+        updated_at=timestamp,
+        last_known_good=last_known_good or starting_commit,
+    )
+
+
+def advance(
+    cycle: UpgradeCycle,
+    destination: CycleState,
+    authorization: ThanosAuthorization,
+    *,
+    action: ThanosAction = ThanosAction.CONTINUE_UPGRADING,
+    note: str = "",
+    now: str | None = None,
+    **updates: Any,
+) -> UpgradeCycle:
+    """Return ``cycle`` moved to ``destination``, recording the transition.
+
+    The standing authorization is re-verified on every transition. It is
+    never consumed: no per-stage prompt is emitted.
+    """
+
+    if cycle.is_terminal:
+        raise CycleTransitionError(f"cycle {cycle.cycle_id} is terminal in {cycle.state.value}")
+    if not transition_is_legal(cycle.state, destination):
+        raise CycleTransitionError(f"illegal transition {cycle.state.value} -> {destination.value}")
+
+    if destination not in (CycleState.PAUSED, CycleState.REVOKED):
+        try:
+            permits(authorization, action)
+        except ThanosError as error:
+            timestamp = now or utc_now_iso()
+            return replace(
+                cycle,
+                state=CycleState.BLOCKED,
+                blocker=str(error),
+                updated_at=timestamp,
+                transitions=cycle.transitions
+                + (
+                    CycleTransition(
+                        source=cycle.state.value,
+                        destination=CycleState.BLOCKED.value,
+                        occurred_at=timestamp,
+                        note=str(error),
+                    ),
+                ),
+            )
+
+    timestamp = now or utc_now_iso()
+    return replace(
+        cycle,
+        state=destination,
+        updated_at=timestamp,
+        transitions=cycle.transitions
+        + (
+            CycleTransition(
+                source=cycle.state.value,
+                destination=destination.value,
+                occurred_at=timestamp,
+                note=note,
+            ),
+        ),
+        **updates,
+    )
+
+
+def record_merge_decision(
+    cycle: UpgradeCycle,
+    decision: MergeDecision,
+    authorization: ThanosAuthorization,
+    *,
+    now: str | None = None,
+) -> UpgradeCycle:
+    """Apply a merge-gate decision to a cycle waiting in MERGING."""
+
+    if decision.allowed:
+        return advance(
+            cycle,
+            CycleState.SYNCHRONIZING,
+            authorization,
+            action=ThanosAction.MERGE,
+            note="autonomous squash merge: all preconditions satisfied",
+            now=now,
+        )
+    return advance(
+        cycle,
+        CycleState.BLOCKED,
+        authorization,
+        action=ThanosAction.MONITOR_CI,
+        note="; ".join(decision.blocking_reasons),
+        now=now,
+        blocker="; ".join(decision.blocking_reasons),
+    )
+
+
+class CycleStore:
+    """Atomic durable persistence for the active and historical cycles."""
+
+    def __init__(self, path: str | Path) -> None:
+        self._path = Path(path)
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def _read(self) -> dict:
+        if not self._path.is_file():
+            return {"active": None, "history": []}
+        try:
+            return json.loads(self._path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return {"active": None, "history": [], "corrupt": True}
+
+    def is_corrupt(self) -> bool:
+        return bool(self._read().get("corrupt"))
+
+    def save(self, cycle: UpgradeCycle) -> UpgradeCycle:
+        """Persist ``cycle`` as the active cycle, archiving it when terminal."""
+
+        data = self._read()
+        data.pop("corrupt", None)
+        history = list(data.get("history") or [])
+        if cycle.is_terminal:
+            history.append(cycle.to_payload())
+            data["active"] = None
+        else:
+            data["active"] = cycle.to_payload()
+        data["history"] = history[-50:]
+        self._atomic_write(data)
+        return cycle
+
+    def resume(self) -> UpgradeCycle | None:
+        """Return the interrupted active cycle, or None."""
+
+        payload = self._read().get("active")
+        if not payload:
+            return None
+        return UpgradeCycle.from_payload(payload)
+
+    def history(self) -> tuple[UpgradeCycle, ...]:
+        return tuple(UpgradeCycle.from_payload(p) for p in self._read().get("history") or [])
+
+    def _atomic_write(self, payload: dict) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        handle, temporary = tempfile.mkstemp(
+            dir=str(self._path.parent), prefix=".cycle-", suffix=".tmp"
+        )
+        try:
+            with os.fdopen(handle, "w", encoding="utf-8") as stream:
+                stream.write(canonical_json(payload))
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.replace(temporary, str(self._path))
+        except BaseException:
+            if os.path.exists(temporary):
+                os.unlink(temporary)
+            raise
+
+
+class CycleLockError(RuntimeError):
+    """Raised when the modification lock cannot be acquired."""
+
+
+def _process_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+class CycleLock:
+    """Single-writer lock. Termux-safe: O_EXCL file, no fcntl, PID reaping."""
+
+    def __init__(self, path: str | Path) -> None:
+        self._path = Path(path)
+        self._held = False
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def acquire(self) -> CycleLock:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            handle = os.open(str(self._path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        except FileExistsError:
+            if self._reap_stale():
+                return self.acquire()
+            raise CycleLockError(f"another upgrade cycle holds {self._path}") from None
+        with os.fdopen(handle, "w", encoding="utf-8") as stream:
+            json.dump({"pid": os.getpid(), "acquired_at": utc_now_iso()}, stream)
+        self._held = True
+        return self
+
+    def _reap_stale(self) -> bool:
+        try:
+            payload = json.loads(self._path.read_text(encoding="utf-8"))
+            pid = int(payload.get("pid", -1))
+        except (OSError, ValueError, TypeError):
+            pid = -1
+        if _process_alive(pid):
+            return False
+        try:
+            os.unlink(str(self._path))
+        except OSError:
+            return False
+        return True
+
+    def release(self) -> None:
+        if self._held:
+            try:
+                os.unlink(str(self._path))
+            except OSError:
+                pass
+            self._held = False
+
+    def __enter__(self) -> CycleLock:
+        return self.acquire()
+
+    def __exit__(self, *_exc: object) -> None:
+        self.release()
+
+
+# Keep the import referenced for Termux signal-safety documentation purposes.
+_SIGNALS_OF_INTEREST = (signal.SIGTERM, signal.SIGINT)

--- a/tests/garvis/test_thanos_cli.py
+++ b/tests/garvis/test_thanos_cli.py
@@ -1,0 +1,118 @@
+"""Tests for the ``garvis thanos`` command-line interface."""
+
+from __future__ import annotations
+
+import pytest
+
+from garvis.thanos_cli import main
+
+
+@pytest.fixture()
+def home(tmp_path, monkeypatch):
+    monkeypatch.setenv("GARVIS_HOME", str(tmp_path))
+    return tmp_path
+
+
+def test_enable_reports_standing_authority(home, capsys) -> None:
+    assert main(["enable"]) == 0
+    out = capsys.readouterr().out
+    assert "THANOS_MODE=ENABLED" in out
+    assert "OWNER=Adrien D. Thomas" in out
+    assert "PER_STAGE_APPROVAL_PROMPTS=0" in out
+    assert "OWNER_MERGE_CHECKPOINTS_PER_CYCLE=0" in out
+    assert "AUTONOMOUS_MERGE_WHEN_GREEN=ENABLED" in out
+    assert "TARGET_VERSION=2.0.0-beta.1" in out
+
+
+def test_enable_does_not_claim_unbuilt_subsystems(home, capsys) -> None:
+    main(["enable"])
+    out = capsys.readouterr().out
+    assert "ROLLBACK=NOT_IMPLEMENTED" in out
+    assert "REPAIR_ENGINE=NOT_IMPLEMENTED" in out
+    assert "CAPABILITY_REGISTRY=NOT_IMPLEMENTED" in out
+
+
+def test_enable_is_idempotent_refusal(home, capsys) -> None:
+    main(["enable"])
+    capsys.readouterr()
+    assert main(["enable"]) == 1
+    assert "REFUSED=ALREADY_ENABLED" in capsys.readouterr().out
+
+
+def test_status_survives_a_restart(home, capsys) -> None:
+    main(["enable"])
+    capsys.readouterr()
+    assert main(["status"]) == 0
+    out = capsys.readouterr().out
+    assert "THANOS_MODE=ENABLED" in out
+    assert "ACTIVE_CYCLE=NONE" in out
+
+
+def test_pause_and_resume_round_trip(home, capsys) -> None:
+    main(["enable"])
+    capsys.readouterr()
+    main(["pause"])
+    assert "THANOS_MODE=PAUSED" in capsys.readouterr().out
+    main(["resume"])
+    assert "THANOS_MODE=ENABLED" in capsys.readouterr().out
+
+
+def test_revoke_requires_a_reason(home) -> None:
+    main(["enable"])
+    with pytest.raises(SystemExit):
+        main(["revoke"])
+
+
+def test_revoke_then_reenable_preserves_history(home, capsys) -> None:
+    main(["enable"])
+    main(["revoke", "--reason", "owner stop"])
+    capsys.readouterr()
+    assert main(["enable"]) == 0
+    assert "SUPERSEDING_REVOKED_AUTHORIZATION" in capsys.readouterr().out
+
+    assert main(["history"]) == 0
+    out = capsys.readouterr().out
+    assert "REVOKED" in out
+    assert "CHAIN_LENGTH=3" in out
+
+
+def test_revocation_is_not_a_permanent_lockout(home, capsys) -> None:
+    main(["enable"])
+    main(["revoke", "--reason", "owner stop"])
+    main(["enable"])
+    capsys.readouterr()
+    assert main(["status"]) == 0
+    assert "THANOS_MODE=ENABLED" in capsys.readouterr().out
+
+
+def test_run_reports_not_implemented_rather_than_success(home, capsys) -> None:
+    main(["enable"])
+    capsys.readouterr()
+    assert main(["run"]) == 3
+    out = capsys.readouterr().out
+    assert "AUTONOMOUS_REPAIR_LOOP=NOT_IMPLEMENTED" in out
+    assert "PASS" not in out
+
+
+def test_health_reports_not_implemented(home, capsys) -> None:
+    assert main(["health"]) == 3
+    assert "RUNTIME_HEALTH_CHECK=NOT_IMPLEMENTED" in capsys.readouterr().out
+
+
+def test_pause_without_authorization_is_refused(home, capsys) -> None:
+    assert main(["pause"]) == 1
+    assert "REFUSED=NO_AUTHORIZATION" in capsys.readouterr().out
+
+
+def test_tampered_store_is_reported(home, capsys) -> None:
+    main(["enable"])
+    capsys.readouterr()
+    path = home / "thanos.json"
+    path.write_text(path.read_text().replace("Adrien D. Thomas", "Someone Else"))
+    main(["status"])
+    assert "THANOS_STATE=TAMPERED" in capsys.readouterr().out
+
+
+def test_empty_history(home, capsys) -> None:
+    assert main(["history"]) == 0
+    assert "AUTHORIZATION_CHAIN=EMPTY" in capsys.readouterr().out

--- a/tests/garvis/test_thanos_mode.py
+++ b/tests/garvis/test_thanos_mode.py
@@ -1,0 +1,385 @@
+"""Tests for the THANOS MODE standing authorization."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from garvis.thanos_mode import (
+    DEFAULT_ALLOWED_ACTIONS,
+    OWNER,
+    REPOSITORY,
+    MergePreconditions,
+    ThanosAction,
+    ThanosAuthorizationStore,
+    ThanosNotEnabledError,
+    ThanosPausedError,
+    ThanosRevokedError,
+    ThanosScopeError,
+    ThanosTamperError,
+    create_authorization,
+    evaluate_merge_gate,
+    is_protected_path,
+    pause_authorization,
+    permits,
+    render_status,
+    resume_authorization,
+    revoke_authorization,
+)
+
+
+def test_creation_is_enabled_and_sealed() -> None:
+    auth = create_authorization()
+    assert auth.owner == OWNER
+    assert auth.repository == REPOSITORY
+    assert auth.enabled is True
+    assert auth.paused is False
+    assert auth.is_active is True
+    assert auth.verify() is True
+    assert auth.authorization_version == 1
+
+
+def test_merge_is_in_default_allowed_actions() -> None:
+    assert ThanosAction.MERGE in DEFAULT_ALLOWED_ACTIONS
+    assert ThanosAction.MERGE.value in create_authorization().allowed_actions
+
+
+def test_active_authorization_permits_merge() -> None:
+    permits(create_authorization(), ThanosAction.MERGE)
+
+
+def test_repeated_merge_checks_do_not_consume_authorization() -> None:
+    auth = create_authorization()
+    for _ in range(50):
+        permits(auth, ThanosAction.MERGE)
+    assert auth.is_active is True
+
+
+def test_paused_authorization_blocks_merge() -> None:
+    paused = pause_authorization(create_authorization())
+    with pytest.raises(ThanosPausedError):
+        permits(paused, ThanosAction.MERGE)
+
+
+def test_revoked_authorization_blocks_merge() -> None:
+    revoked = revoke_authorization(create_authorization(), reason="owner stop")
+    with pytest.raises(ThanosRevokedError):
+        permits(revoked, ThanosAction.MERGE)
+
+
+def test_repository_mismatch_blocks_merge() -> None:
+    with pytest.raises(ThanosScopeError):
+        permits(create_authorization(), ThanosAction.MERGE, repository="ProCityHub/AGI")
+
+
+def test_runtime_mismatch_blocks_merge() -> None:
+    with pytest.raises(ThanosScopeError):
+        permits(create_authorization(), ThanosAction.MERGE, runtime_scope="other")
+
+
+def test_tampered_authorization_blocks_merge() -> None:
+    from dataclasses import replace
+
+    auth = create_authorization()
+    tampered = replace(auth, owner="Someone Else")
+    with pytest.raises(ThanosTamperError):
+        permits(tampered, ThanosAction.MERGE)
+
+
+def test_status_reports_autonomous_merge_when_green() -> None:
+    status = render_status(create_authorization())
+    assert "AUTONOMOUS_MERGE_WHEN_GREEN=ENABLED" in status
+    assert "OWNER_MERGE_CHECKPOINTS_PER_CYCLE=0" in status
+
+
+def test_authorization_is_not_consumed_by_use() -> None:
+    auth = create_authorization()
+    for _ in range(50):
+        permits(auth, ThanosAction.COMMIT)
+        permits(auth, ThanosAction.PUSH)
+        permits(auth, ThanosAction.CREATE_PULL_REQUEST)
+    assert auth.is_active is True
+
+
+def test_zero_per_stage_prompts_in_status() -> None:
+    assert "PER_STAGE_APPROVAL_PROMPTS=0" in render_status(create_authorization())
+
+
+def test_repository_scope_is_enforced() -> None:
+    auth = create_authorization()
+    with pytest.raises(ThanosScopeError):
+        permits(auth, ThanosAction.EDIT, repository="ProCityHub/AGI")
+
+
+def test_runtime_scope_is_enforced() -> None:
+    auth = create_authorization()
+    with pytest.raises(ThanosScopeError):
+        permits(auth, ThanosAction.EDIT, runtime_scope="other-runtime")
+
+
+def test_pause_and_resume() -> None:
+    auth = create_authorization()
+    paused = pause_authorization(auth)
+    assert paused.is_active is False
+    with pytest.raises(ThanosPausedError):
+        permits(paused, ThanosAction.EDIT)
+    resumed = resume_authorization(paused)
+    assert resumed.is_active is True
+    permits(resumed, ThanosAction.EDIT)
+
+
+def test_revocation_stops_future_work() -> None:
+    auth = create_authorization()
+    revoked = revoke_authorization(auth, reason="owner stopped the experiment")
+    assert revoked.is_revoked is True
+    assert revoked.enabled is False
+    with pytest.raises(ThanosRevokedError):
+        permits(revoked, ThanosAction.EDIT)
+
+
+def test_revocation_requires_a_reason() -> None:
+    with pytest.raises(ValueError):
+        revoke_authorization(create_authorization(), reason="   ")
+
+
+def test_revoked_grant_cannot_be_resumed() -> None:
+    revoked = revoke_authorization(create_authorization(), reason="stop")
+    with pytest.raises(ThanosRevokedError):
+        resume_authorization(revoked)
+
+
+def test_disabled_grant_raises_not_enabled() -> None:
+    from dataclasses import replace
+
+    auth = create_authorization()
+    disabled = replace(auth, enabled=False, record_hash="").sealed()
+    with pytest.raises(ThanosNotEnabledError):
+        permits(disabled, ThanosAction.EDIT)
+
+
+def test_unknown_action_is_rejected() -> None:
+    auth = create_authorization()
+    with pytest.raises(ThanosScopeError):
+        permits(auth, "transfer-money")
+
+
+# --------------------------------------------------------------------------
+# Persistence
+# --------------------------------------------------------------------------
+
+
+def test_persistence_round_trip(tmp_path) -> None:
+    store = ThanosAuthorizationStore(tmp_path / "thanos.json")
+    assert store.load() is None
+    auth = create_authorization()
+    store.append(auth)
+
+    reloaded = ThanosAuthorizationStore(tmp_path / "thanos.json").load()
+    assert reloaded is not None
+    assert reloaded.authorization_id == auth.authorization_id
+    assert reloaded.record_hash == auth.record_hash
+    assert reloaded.is_active is True
+
+
+def test_chain_head_reflects_latest_amendment(tmp_path) -> None:
+    store = ThanosAuthorizationStore(tmp_path / "thanos.json")
+    auth = store.append(create_authorization())
+    store.append(pause_authorization(auth))
+
+    head = store.load()
+    assert head is not None
+    assert head.paused is True
+    assert len(store.history()) == 2
+
+
+def test_revocation_survives_restart(tmp_path) -> None:
+    path = tmp_path / "thanos.json"
+    store = ThanosAuthorizationStore(path)
+    auth = store.append(create_authorization())
+    store.append(revoke_authorization(auth, reason="owner revoked"))
+
+    fresh = ThanosAuthorizationStore(path).load()
+    assert fresh is not None
+    with pytest.raises(ThanosRevokedError):
+        permits(fresh, ThanosAction.COMMIT)
+
+
+def test_broken_link_is_rejected(tmp_path) -> None:
+    store = ThanosAuthorizationStore(tmp_path / "thanos.json")
+    store.append(create_authorization())
+    orphan = create_authorization()  # links to genesis, not to the head
+    with pytest.raises(ThanosTamperError):
+        store.append(orphan)
+
+
+def test_tampered_record_is_detected(tmp_path) -> None:
+    path = tmp_path / "thanos.json"
+    store = ThanosAuthorizationStore(path)
+    store.append(create_authorization())
+
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    raw["chain"][0]["allowed_actions"].append("merge")
+    path.write_text(json.dumps(raw), encoding="utf-8")
+
+    with pytest.raises(ThanosTamperError):
+        ThanosAuthorizationStore(path).load()
+
+
+def test_revocation_cannot_be_erased_silently(tmp_path) -> None:
+    path = tmp_path / "thanos.json"
+    store = ThanosAuthorizationStore(path)
+    auth = store.append(create_authorization())
+    store.append(revoke_authorization(auth, reason="owner revoked"))
+
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    raw["chain"][1]["revoked_at"] = None
+    raw["chain"][1]["enabled"] = True
+    path.write_text(json.dumps(raw), encoding="utf-8")
+
+    with pytest.raises(ThanosTamperError):
+        ThanosAuthorizationStore(path).load()
+
+
+def test_corrupt_store_is_detected(tmp_path) -> None:
+    path = tmp_path / "thanos.json"
+    path.write_text("{not json", encoding="utf-8")
+    with pytest.raises(ThanosTamperError):
+        ThanosAuthorizationStore(path).load()
+
+
+def test_unsealed_record_is_not_persisted(tmp_path) -> None:
+    from dataclasses import replace
+
+    store = ThanosAuthorizationStore(tmp_path / "thanos.json")
+    auth = replace(create_authorization(), record_hash="")
+    with pytest.raises(ThanosTamperError):
+        store.append(auth)
+
+
+def test_atomic_write_leaves_no_temp_files(tmp_path) -> None:
+    store = ThanosAuthorizationStore(tmp_path / "thanos.json")
+    store.append(create_authorization())
+    leftovers = [p.name for p in tmp_path.iterdir() if p.name.startswith(".thanos-")]
+    assert leftovers == []
+
+
+# --------------------------------------------------------------------------
+# Protected paths
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "src/garvis/thanos_mode.py",
+        "src/garvis/stage_gate.py",
+        "src/garvis/github_maintenance.py",
+        ".github/workflows/tests.yml",
+        ".github/CODEOWNERS",
+    ],
+)
+def test_governance_paths_are_protected(path: str) -> None:
+    assert is_protected_path(path) is True
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["src/garvis/assistant.py", "docs/README.md", "tests/garvis/test_cli.py"],
+)
+def test_ordinary_paths_are_not_protected(path: str) -> None:
+    assert is_protected_path(path) is False
+
+
+def test_status_for_absent_authorization() -> None:
+    status = render_status(None)
+    assert "THANOS_MODE=DISABLED" in status
+    assert "STANDING_AUTHORITY=ABSENT" in status
+
+
+# --------------------------------------------------------------------------
+# Autonomous merge gate
+# --------------------------------------------------------------------------
+
+
+def _green(**overrides) -> MergePreconditions:
+    base = {
+        "repository": REPOSITORY,
+        "changed_paths": ("src/garvis/assistant.py",),
+        "expected_head_sha": "abc123",
+        "actual_head_sha": "abc123",
+        "required_checks_complete": True,
+        "required_checks_passed": True,
+        "tested_artifact_sha": "tree1",
+        "proposed_artifact_sha": "tree1",
+        "base_sha_at_test_time": "base1",
+        "base_sha_now": "base1",
+    }
+    base.update(overrides)
+    return MergePreconditions(**base)
+
+
+def test_green_ordinary_change_merges_autonomously() -> None:
+    decision = evaluate_merge_gate(create_authorization(), _green())
+    assert decision.allowed is True
+    assert decision.blocking_reasons == ()
+    assert decision.requires_owner_review is False
+
+
+def test_moved_head_blocks_merge() -> None:
+    decision = evaluate_merge_gate(create_authorization(), _green(actual_head_sha="def456"))
+    assert decision.allowed is False
+    assert any("head moved" in r for r in decision.blocking_reasons)
+
+
+def test_failed_checks_block_merge() -> None:
+    decision = evaluate_merge_gate(create_authorization(), _green(required_checks_passed=False))
+    assert decision.allowed is False
+
+
+def test_incomplete_checks_block_merge() -> None:
+    decision = evaluate_merge_gate(create_authorization(), _green(required_checks_complete=False))
+    assert decision.allowed is False
+
+
+def test_artifact_mismatch_blocks_merge() -> None:
+    decision = evaluate_merge_gate(create_authorization(), _green(proposed_artifact_sha="tree2"))
+    assert decision.allowed is False
+
+
+def test_advanced_base_blocks_merge() -> None:
+    decision = evaluate_merge_gate(create_authorization(), _green(base_sha_now="base2"))
+    assert decision.allowed is False
+    assert any("unrelated work" in r for r in decision.blocking_reasons)
+
+
+def test_detected_secret_blocks_merge() -> None:
+    decision = evaluate_merge_gate(create_authorization(), _green(secrets_detected=True))
+    assert decision.allowed is False
+
+
+def test_missing_rollback_blocks_merge() -> None:
+    decision = evaluate_merge_gate(create_authorization(), _green(rollback_available=False))
+    assert decision.allowed is False
+
+
+def test_revoked_authorization_blocks_merge_gate() -> None:
+    revoked = revoke_authorization(create_authorization(), reason="owner stop")
+    assert evaluate_merge_gate(revoked, _green()).allowed is False
+
+
+def test_governance_change_requires_owner_review() -> None:
+    decision = evaluate_merge_gate(
+        create_authorization(),
+        _green(changed_paths=("src/garvis/assistant.py", "src/garvis/thanos_mode.py")),
+    )
+    assert decision.allowed is False
+    assert decision.requires_owner_review is True
+    assert "src/garvis/thanos_mode.py" in decision.protected_paths
+
+
+def test_workflow_change_requires_owner_review() -> None:
+    decision = evaluate_merge_gate(
+        create_authorization(), _green(changed_paths=(".github/workflows/tests.yml",))
+    )
+    assert decision.requires_owner_review is True

--- a/tests/garvis/test_upgrade_cycle.py
+++ b/tests/garvis/test_upgrade_cycle.py
@@ -1,0 +1,329 @@
+"""Tests for the THANOS autonomous upgrade-cycle state machine."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from garvis.thanos_mode import (
+    MergePreconditions,
+    ThanosAction,
+    create_authorization,
+    evaluate_merge_gate,
+    pause_authorization,
+    revoke_authorization,
+)
+from garvis.upgrade_cycle import (
+    CycleLock,
+    CycleLockError,
+    CycleState,
+    CycleStore,
+    CycleTransitionError,
+    advance,
+    new_cycle,
+    record_merge_decision,
+    transition_is_legal,
+)
+
+
+@pytest.fixture()
+def auth():
+    return create_authorization()
+
+
+@pytest.fixture()
+def cycle():
+    return new_cycle(
+        objective="repair failing lint job",
+        starting_commit="049fc9d",
+        starting_version="0.3.1",
+    )
+
+
+# --------------------------------------------------------------------------
+# Transitions
+# --------------------------------------------------------------------------
+
+
+def test_pipeline_order_is_enforced(cycle, auth) -> None:
+    moved = advance(cycle, CycleState.OBSERVING, auth)
+    assert moved.state is CycleState.OBSERVING
+    with pytest.raises(CycleTransitionError):
+        advance(moved, CycleState.MERGING, auth)
+
+
+def test_every_transition_is_recorded(cycle, auth) -> None:
+    current = cycle
+    for state in (
+        CycleState.OBSERVING,
+        CycleState.RESEARCHING,
+        CycleState.DIAGNOSING,
+    ):
+        current = advance(current, state, auth)
+    assert len(current.transitions) == 3
+    assert current.transitions[0].source == CycleState.IDLE.value
+    assert current.transitions[-1].destination == CycleState.DIAGNOSING.value
+    assert all(t.occurred_at for t in current.transitions)
+
+
+def test_failed_validation_returns_to_patching(cycle, auth) -> None:
+    assert transition_is_legal(CycleState.TESTING, CycleState.PATCHING)
+    assert transition_is_legal(CycleState.LINTING, CycleState.PATCHING)
+    assert transition_is_legal(CycleState.SECURITY_REVIEWING, CycleState.PATCHING)
+
+
+def test_ci_failure_enters_repair_loop(auth) -> None:
+    assert transition_is_legal(CycleState.WAITING_FOR_CI, CycleState.REPAIRING_CI)
+    assert transition_is_legal(CycleState.REPAIRING_CI, CycleState.PATCHING)
+    assert transition_is_legal(CycleState.REPAIRING_CI, CycleState.WAITING_FOR_CI)
+
+
+def test_unhealthy_candidate_can_roll_back() -> None:
+    assert transition_is_legal(CycleState.HEALTH_CHECKING, CycleState.ROLLING_BACK)
+    assert transition_is_legal(CycleState.PROMOTING, CycleState.ROLLING_BACK)
+    assert transition_is_legal(CycleState.ROLLING_BACK, CycleState.OBSERVING)
+
+
+def test_terminal_cycle_cannot_advance(cycle, auth) -> None:
+    failed = advance(cycle, CycleState.FAILED, auth)
+    assert failed.is_terminal is True
+    with pytest.raises(CycleTransitionError):
+        advance(failed, CycleState.OBSERVING, auth)
+
+
+def test_no_per_stage_prompt_is_emitted(cycle, auth, capsys) -> None:
+    current = cycle
+    for state in (
+        CycleState.OBSERVING,
+        CycleState.RESEARCHING,
+        CycleState.DIAGNOSING,
+        CycleState.SPECIFYING,
+        CycleState.PLANNING,
+    ):
+        current = advance(current, state, auth)
+    assert capsys.readouterr().out == ""
+    assert current.state is CycleState.PLANNING
+
+
+# --------------------------------------------------------------------------
+# Authorization interaction
+# --------------------------------------------------------------------------
+
+
+def test_revoked_authorization_blocks_the_cycle(cycle) -> None:
+    revoked = revoke_authorization(create_authorization(), reason="owner stop")
+    blocked = advance(cycle, CycleState.OBSERVING, revoked)
+    assert blocked.state is CycleState.BLOCKED
+    assert "revoked" in (blocked.blocker or "").lower()
+
+
+def test_paused_authorization_blocks_the_cycle(cycle) -> None:
+    paused = pause_authorization(create_authorization())
+    blocked = advance(cycle, CycleState.OBSERVING, paused)
+    assert blocked.state is CycleState.BLOCKED
+
+
+def test_owner_pause_is_always_reachable(cycle, auth) -> None:
+    working = advance(cycle, CycleState.OBSERVING, auth)
+    paused = advance(working, CycleState.PAUSED, auth)
+    assert paused.state is CycleState.PAUSED
+    assert transition_is_legal(CycleState.PAUSED, CycleState.OBSERVING)
+
+
+def test_authorization_is_not_consumed_across_a_full_pipeline(cycle, auth) -> None:
+    current = cycle
+    for state in (
+        CycleState.OBSERVING,
+        CycleState.RESEARCHING,
+        CycleState.DIAGNOSING,
+        CycleState.SPECIFYING,
+        CycleState.PLANNING,
+        CycleState.PREPARING_WORKSPACE,
+        CycleState.PATCHING,
+        CycleState.FORMATTING,
+        CycleState.LINTING,
+        CycleState.TYPE_CHECKING,
+        CycleState.TESTING,
+    ):
+        current = advance(current, state, auth, action=ThanosAction.EDIT)
+    assert current.state is CycleState.TESTING
+    assert auth.is_active is True
+
+
+# --------------------------------------------------------------------------
+# Merge gate integration
+# --------------------------------------------------------------------------
+
+
+def _at_merging(cycle, auth):
+    current = cycle
+    for state in (
+        CycleState.OBSERVING,
+        CycleState.RESEARCHING,
+        CycleState.DIAGNOSING,
+        CycleState.SPECIFYING,
+        CycleState.PLANNING,
+        CycleState.PREPARING_WORKSPACE,
+        CycleState.PATCHING,
+        CycleState.FORMATTING,
+        CycleState.LINTING,
+        CycleState.TYPE_CHECKING,
+        CycleState.TESTING,
+        CycleState.SECURITY_REVIEWING,
+        CycleState.PACKAGING,
+        CycleState.COMMITTING,
+        CycleState.PUSHING,
+        CycleState.OPENING_PR,
+        CycleState.WAITING_FOR_CI,
+        CycleState.MERGING,
+    ):
+        current = advance(current, state, auth)
+    return current
+
+
+def _preconditions(**overrides) -> MergePreconditions:
+    base = {
+        "repository": "ProCityHub/GARVIS",
+        "changed_paths": ("src/garvis/assistant.py",),
+        "expected_head_sha": "abc123",
+        "actual_head_sha": "abc123",
+        "required_checks_complete": True,
+        "required_checks_passed": True,
+        "tested_artifact_sha": "tree1",
+        "proposed_artifact_sha": "tree1",
+        "base_sha_at_test_time": "base1",
+        "base_sha_now": "base1",
+    }
+    base.update(overrides)
+    return MergePreconditions(**base)
+
+
+def test_green_cycle_merges_without_owner_checkpoint(cycle, auth) -> None:
+    at_merge = _at_merging(cycle, auth)
+    decision = evaluate_merge_gate(auth, _preconditions())
+    merged = record_merge_decision(at_merge, decision, auth)
+    assert merged.state is CycleState.SYNCHRONIZING
+    assert merged.blocker is None
+
+
+def test_red_ci_blocks_the_merge(cycle, auth) -> None:
+    at_merge = _at_merging(cycle, auth)
+    decision = evaluate_merge_gate(auth, _preconditions(required_checks_passed=False))
+    blocked = record_merge_decision(at_merge, decision, auth)
+    assert blocked.state is CycleState.BLOCKED
+    assert "did not pass" in (blocked.blocker or "")
+
+
+def test_governance_change_blocks_self_merge(cycle, auth) -> None:
+    at_merge = _at_merging(cycle, auth)
+    decision = evaluate_merge_gate(
+        auth, _preconditions(changed_paths=("src/garvis/thanos_mode.py",))
+    )
+    blocked = record_merge_decision(at_merge, decision, auth)
+    assert blocked.state is CycleState.BLOCKED
+    assert decision.requires_owner_review is True
+
+
+# --------------------------------------------------------------------------
+# Durability and resume
+# --------------------------------------------------------------------------
+
+
+def test_interrupted_cycle_resumes(tmp_path, cycle, auth) -> None:
+    store = CycleStore(tmp_path / "cycles.json")
+    working = advance(cycle, CycleState.OBSERVING, auth)
+    working = advance(working, CycleState.RESEARCHING, auth)
+    store.save(working)
+
+    resumed = CycleStore(tmp_path / "cycles.json").resume()
+    assert resumed is not None
+    assert resumed.cycle_id == working.cycle_id
+    assert resumed.state is CycleState.RESEARCHING
+    assert len(resumed.transitions) == 2
+    assert resumed.starting_commit == "049fc9d"
+
+
+def test_no_active_cycle_returns_none(tmp_path) -> None:
+    assert CycleStore(tmp_path / "cycles.json").resume() is None
+
+
+def test_terminal_cycle_is_archived(tmp_path, cycle, auth) -> None:
+    store = CycleStore(tmp_path / "cycles.json")
+    store.save(advance(cycle, CycleState.FAILED, auth))
+    assert store.resume() is None
+    assert len(store.history()) == 1
+    assert store.history()[0].state is CycleState.FAILED
+
+
+def test_corrupt_state_is_detected(tmp_path) -> None:
+    path = tmp_path / "cycles.json"
+    path.write_text("{broken", encoding="utf-8")
+    store = CycleStore(path)
+    assert store.is_corrupt() is True
+    assert store.resume() is None
+
+
+def test_atomic_write_leaves_no_temp_files(tmp_path, cycle) -> None:
+    CycleStore(tmp_path / "cycles.json").save(cycle)
+    leftovers = [p.name for p in tmp_path.iterdir() if p.name.startswith(".cycle-")]
+    assert leftovers == []
+
+
+def test_evidence_survives_the_round_trip(tmp_path, cycle, auth) -> None:
+    store = CycleStore(tmp_path / "cycles.json")
+    working = advance(
+        cycle,
+        CycleState.OBSERVING,
+        auth,
+        evidence={"source_url": "https://docs.python.org/3.9/", "confidence": "high"},
+        changed_files=("src/garvis/assistant.py",),
+    )
+    store.save(working)
+    resumed = store.resume()
+    assert resumed is not None
+    assert resumed.evidence["confidence"] == "high"
+    assert resumed.changed_files == ("src/garvis/assistant.py",)
+
+
+# --------------------------------------------------------------------------
+# Concurrency lock
+# --------------------------------------------------------------------------
+
+
+def test_second_cycle_cannot_acquire_the_lock(tmp_path) -> None:
+    first = CycleLock(tmp_path / "cycle.lock").acquire()
+    try:
+        with pytest.raises(CycleLockError):
+            CycleLock(tmp_path / "cycle.lock").acquire()
+    finally:
+        first.release()
+
+
+def test_lock_is_reusable_after_release(tmp_path) -> None:
+    path = tmp_path / "cycle.lock"
+    CycleLock(path).acquire().release()
+    second = CycleLock(path).acquire()
+    second.release()
+    assert not path.exists()
+
+
+def test_stale_lock_from_dead_process_is_reaped(tmp_path) -> None:
+    path = tmp_path / "cycle.lock"
+    path.write_text('{"pid": 999999, "acquired_at": "2026-07-24T00:00:00Z"}')
+    lock = CycleLock(path).acquire()
+    lock.release()
+
+
+def test_live_lock_is_not_reaped(tmp_path) -> None:
+    path = tmp_path / "cycle.lock"
+    path.write_text(f'{{"pid": {os.getpid()}, "acquired_at": "2026-07-24T00:00:00Z"}}')
+    with pytest.raises(CycleLockError):
+        CycleLock(path).acquire()
+
+
+def test_lock_context_manager_releases(tmp_path) -> None:
+    path = tmp_path / "cycle.lock"
+    with CycleLock(path):
+        assert path.exists()
+    assert not path.exists()


### PR DESCRIPTION
Adds the Adrien D. Thomas THANOS MODE standing authorization, durable upgrade-cycle state machine, Termux CLI, and tests. Target designation: GARVIS Version 2 Full AGI Beta (2.0.0-beta.1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added THANOS authorization management with enable, status, pause, resume, history, and revoke commands.
  * Added persistent, tamper-detecting authorization history with repository and runtime scope enforcement.
  * Added restartable upgrade-cycle tracking with safe transitions, pause/revoke handling, resume support, and concurrency protection.
  * Added merge gating that blocks unsafe changes and requires owner review for protected paths.
  * Clearly reports unavailable run and health capabilities instead of indicating success.

* **Tests**
  * Added comprehensive coverage for authorization, persistence, tamper detection, upgrade cycles, merge decisions, and locking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->