### PR TITLE
feat(provider): add remote inference bridge

### DIFF
--- a/src/garvis/assistant.py
+++ b/src/garvis/assistant.py
@@ -19,6 +19,10 @@ from agents import Agent, Runner, SQLiteSession
 from .anthropic_backend import configure_anthropic, is_anthropic_model
 from .bounded_session import BoundedSession
 from .core_memory import core_identity_prompt
+from .provider_bridge import (
+    configure_openai_compatible,
+    is_openai_compatible_model,
+)
 from .repository_context import ground_message, should_ground_repository
 
 DEFAULT_MODEL = "gpt-5.1"
@@ -193,6 +197,8 @@ class GarvisAssistant:
         self.model = model or os.getenv("GARVIS_MODEL", DEFAULT_MODEL)
         if is_anthropic_model(self.model):
             self.model = configure_anthropic(self.model)
+        elif is_openai_compatible_model(self.model):
+            self.model = configure_openai_compatible(self.model)
         self.max_turns = max_turns
         self.persist_memory = persist_memory
         self.session_db = session_db or self._default_session_db()

--- a/src/garvis/cli.py
+++ b/src/garvis/cli.py
@@ -195,6 +195,10 @@ def _run_local(args: argparse.Namespace) -> int:
 
 def _check_configuration(model: str | None = None) -> str | None:
     from .anthropic_backend import is_anthropic_model
+    from .provider_bridge import (
+        is_openai_compatible_model,
+        provider_configuration_error,
+    )
 
     resolved = model or os.getenv("GARVIS_MODEL", DEFAULT_REMOTE_MODEL)
     if is_anthropic_model(resolved):
@@ -205,6 +209,8 @@ def _check_configuration(model: str | None = None) -> str | None:
                 "the repository."
             )
         return None
+    if is_openai_compatible_model(resolved):
+        return provider_configuration_error(resolved)
     if resolved.strip().lower().startswith("litellm/"):
         return None  # provider-specific keys; litellm reports its own errors
     if not os.getenv("OPENAI_API_KEY"):

--- a/src/garvis/provider_bridge.py
+++ b/src/garvis/provider_bridge.py
@@ -1,0 +1,133 @@
+"""Remote inference-provider bridge for GARVIS.
+
+Project and conceptual architecture: Adrien D. Thomas (ProCityHub/GARVIS).
+
+GARVIS remains the orchestrator. Authorized external models are interchangeable
+inference engines, not identities and not execution authorities. API keys are
+read only from environment variables. Configuration performs no network call.
+
+Python 3.9 compatible.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional
+from urllib.parse import urlparse
+
+from openai import AsyncOpenAI
+
+from agents import set_default_openai_api, set_default_openai_client, set_tracing_disabled
+
+__all__ = [
+    "ProviderConfigurationError",
+    "ProviderSpec",
+    "configure_openai_compatible",
+    "is_openai_compatible_model",
+    "provider_configuration_error",
+    "provider_name",
+    "required_api_key_environment",
+]
+
+
+class ProviderConfigurationError(RuntimeError):
+    """Raised when a requested remote provider is not safely configured."""
+
+
+@dataclass(frozen=True)
+class ProviderSpec:
+    """Configuration required for one OpenAI-compatible provider."""
+
+    name: str
+    prefix: str
+    base_url: str
+    api_key_environment: str
+
+
+_PROVIDER_SPECS = {
+    "groq": ProviderSpec("groq", "groq/", "https://api.groq.com/openai/v1", "GROQ_API_KEY"),
+    "openrouter": ProviderSpec(
+        "openrouter", "openrouter/", "https://openrouter.ai/api/v1", "OPENROUTER_API_KEY"
+    ),
+    "compatible": ProviderSpec("compatible", "compatible/", "", "GARVIS_COMPAT_API_KEY"),
+}
+
+
+def _split_model(model: object) -> Optional[tuple[ProviderSpec, str]]:
+    if not isinstance(model, str):
+        return None
+    clean = model.strip()
+    lowered = clean.casefold()
+    for spec in _PROVIDER_SPECS.values():
+        if lowered.startswith(spec.prefix):
+            bare_model = clean[len(spec.prefix) :].strip()
+            if not bare_model:
+                raise ProviderConfigurationError(f"{spec.name} model identifier is empty")
+            return spec, bare_model
+    return None
+
+
+def is_openai_compatible_model(model: object) -> bool:
+    try:
+        return _split_model(model) is not None
+    except ProviderConfigurationError:
+        return True
+
+
+def provider_name(model: object) -> Optional[str]:
+    resolved = _split_model(model)
+    return resolved[0].name if resolved is not None else None
+
+
+def required_api_key_environment(model: object) -> Optional[str]:
+    resolved = _split_model(model)
+    return resolved[0].api_key_environment if resolved is not None else None
+
+
+def _compatible_base_url(spec: ProviderSpec) -> str:
+    if spec.name != "compatible":
+        return spec.base_url
+    base_url = os.getenv("GARVIS_COMPAT_BASE_URL", "").strip()
+    if not base_url:
+        raise ProviderConfigurationError("GARVIS_COMPAT_BASE_URL is not set for compatible/ models")
+    parsed = urlparse(base_url)
+    if parsed.scheme != "https" or not parsed.netloc:
+        raise ProviderConfigurationError("GARVIS_COMPAT_BASE_URL must be an absolute HTTPS URL")
+    if parsed.username or parsed.password:
+        raise ProviderConfigurationError("GARVIS_COMPAT_BASE_URL must not contain credentials")
+    return base_url.rstrip("/")
+
+
+def _resolved_configuration(model: str) -> tuple[ProviderSpec, str, str, str]:
+    resolved = _split_model(model)
+    if resolved is None:
+        raise ProviderConfigurationError(f"model is not handled by the provider bridge: {model}")
+    spec, bare_model = resolved
+    api_key = os.getenv(spec.api_key_environment, "").strip()
+    if not api_key:
+        raise ProviderConfigurationError(
+            f"{spec.api_key_environment} is not set for {spec.name} provider"
+        )
+    return spec, bare_model, _compatible_base_url(spec), api_key
+
+
+def provider_configuration_error(model: object) -> Optional[str]:
+    if not isinstance(model, str):
+        return None
+    try:
+        _resolved_configuration(model)
+    except ProviderConfigurationError as error:
+        return str(error)
+    return None
+
+
+def configure_openai_compatible(model: str) -> str:
+    """Configure the Agents SDK and return the provider's bare model ID."""
+
+    _spec, bare_model, base_url, api_key = _resolved_configuration(model)
+    client = AsyncOpenAI(base_url=base_url, api_key=api_key)
+    set_default_openai_client(client, use_for_tracing=False)
+    set_default_openai_api("chat_completions")
+    set_tracing_disabled(True)
+    return bare_model

--- a/tests/garvis/test_provider_bridge.py
+++ b/tests/garvis/test_provider_bridge.py
@@ -1,0 +1,102 @@
+"""Tests for the GARVIS remote provider bridge."""
+
+from __future__ import annotations
+
+import pytest
+
+from garvis import provider_bridge
+from garvis.cli import _check_configuration
+
+
+def _capture(monkeypatch):
+    captured = {}
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            captured["client"] = kwargs
+
+    monkeypatch.setattr(provider_bridge, "AsyncOpenAI", FakeClient)
+    monkeypatch.setattr(
+        provider_bridge,
+        "set_default_openai_client",
+        lambda client, use_for_tracing: captured.update(
+            client_object=client, use_for_tracing=use_for_tracing
+        ),
+    )
+    monkeypatch.setattr(
+        provider_bridge,
+        "set_default_openai_api",
+        lambda value: captured.update(api=value),
+    )
+    monkeypatch.setattr(
+        provider_bridge,
+        "set_tracing_disabled",
+        lambda value: captured.update(tracing_disabled=value),
+    )
+    return captured
+
+
+@pytest.mark.parametrize(
+    ("model", "provider"),
+    [
+        ("groq/openai/gpt-oss-20b", "groq"),
+        ("openrouter/openrouter/free", "openrouter"),
+        ("compatible/vendor/model", "compatible"),
+    ],
+)
+def test_provider_prefixes(model: str, provider: str) -> None:
+    assert provider_bridge.is_openai_compatible_model(model) is True
+    assert provider_bridge.provider_name(model) == provider
+
+
+def test_unknown_prefix_is_not_claimed() -> None:
+    assert provider_bridge.is_openai_compatible_model("gpt-5.1") is False
+
+
+def test_groq_configures_existing_openai_sdk(monkeypatch) -> None:
+    monkeypatch.setenv("GROQ_API_KEY", "test-groq-key")
+    captured = _capture(monkeypatch)
+    model = provider_bridge.configure_openai_compatible("groq/openai/gpt-oss-20b")
+    assert model == "openai/gpt-oss-20b"
+    assert captured["client"]["base_url"] == "https://api.groq.com/openai/v1"
+    assert captured["client"]["api_key"] == "test-groq-key"
+    assert captured["use_for_tracing"] is False
+    assert captured["api"] == "chat_completions"
+    assert captured["tracing_disabled"] is True
+
+
+def test_openrouter_configures_existing_openai_sdk(monkeypatch) -> None:
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-openrouter-key")
+    captured = _capture(monkeypatch)
+    model = provider_bridge.configure_openai_compatible("openrouter/openrouter/free")
+    assert model == "openrouter/free"
+    assert captured["client"]["base_url"] == "https://openrouter.ai/api/v1"
+
+
+def test_generic_provider_requires_https(monkeypatch) -> None:
+    monkeypatch.setenv("GARVIS_COMPAT_API_KEY", "test-key")
+    monkeypatch.setenv("GARVIS_COMPAT_BASE_URL", "http://example.com/v1")
+    with pytest.raises(provider_bridge.ProviderConfigurationError):
+        provider_bridge.configure_openai_compatible("compatible/vendor/model")
+
+
+def test_generic_provider_accepts_https(monkeypatch) -> None:
+    monkeypatch.setenv("GARVIS_COMPAT_API_KEY", "test-key")
+    monkeypatch.setenv("GARVIS_COMPAT_BASE_URL", "https://models.example/v1/")
+    captured = _capture(monkeypatch)
+    model = provider_bridge.configure_openai_compatible("compatible/vendor/model")
+    assert model == "vendor/model"
+    assert captured["client"]["base_url"] == "https://models.example/v1"
+
+
+def test_cli_accepts_configured_groq(monkeypatch) -> None:
+    monkeypatch.setenv("GROQ_API_KEY", "test-key")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    assert _check_configuration("groq/openai/gpt-oss-20b") is None
+
+
+def test_cli_rejects_unconfigured_openrouter(monkeypatch) -> None:
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    error = _check_configuration("openrouter/openrouter/free")
+    assert error is not None
+    assert "OPENROUTER_API_KEY" in error


### PR DESCRIPTION
## GARVIS Remote Provider Bridge V1

Creator and conceptual architecture: **Adrien D. Thomas**

This change gives GARVIS a lightweight remote-inference bridge so large
reasoning and coding workloads do not have to run through the local GGUF
model inside Termux.

### Provider prefixes

- `groq/<model-id>`
- `openrouter/<model-id>`
- `compatible/<model-id>`

### Properties

- Uses the OpenAI-compatible client already present in GARVIS.
- Reads API credentials only from environment variables.
- Does not store or print API keys.
- Requires HTTPS for generic compatible providers.
- Disables remote tracing.
- Preserves GARVIS identity, memory, evidence, capability controls, and
  THANOS authorization boundaries.
- Makes no model-provider request during configuration or tests.

### Validation completed locally

- Python 3.9 syntax
- Python compilation
- Ruff checking and formatting
- Provider bridge focused tests
- Full GARVIS tests
- Focused mypy validation
- Diff and changed-file verification

This pull request does not merge, restart, deploy, or execute a model API.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for OpenAI-compatible models, including Groq, OpenRouter, and custom HTTPS endpoints.
  - Added provider-specific configuration and API key validation.
  - Added support for configuring custom compatible-provider base URLs.

- **Bug Fixes**
  - Improved startup validation with clearer errors when provider credentials or endpoint settings are missing.

- **Tests**
  - Added coverage for provider detection, SDK configuration, secure endpoint validation, and CLI setup checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->