### PR TITLE
feat(guard): repository guard, ledgers, and retractions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,21 @@
+# GARVIS governance ownership
+# Owner and final merge authority: Adrien D. Thomas (@ProCityHub)
+#
+# Pair with branch protection on main:
+#   - Require a pull request before merging
+#   - Require review from Code Owners
+#   - Do not allow bypassing the above settings
+#
+# This file is the enforcement wall. It lives on GitHub's side, outside the
+# runtime GARVIS can rewrite.
+
+/.github/                          @ProCityHub
+/FROZEN_FILES.txt                  @ProCityHub
+/GOVERNED_FILES.txt                @ProCityHub
+/RETRACTIONS.md                    @ProCityHub
+/src/garvis/thanos_mode.py         @ProCityHub
+/src/garvis/stage_gate.py          @ProCityHub
+/src/garvis/stage_gate_store.py    @ProCityHub
+/src/garvis/upgrade_cycle.py       @ProCityHub
+/src/garvis/upgrade_research.py    @ProCityHub
+/src/garvis/github_maintenance.py  @ProCityHub

--- a/.github/scripts/guard_check.py
+++ b/.github/scripts/guard_check.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""GARVIS repository guard checks.
+
+Owner and final authority: Adrien D. Thomas (ProCityHub/GARVIS).
+
+Ported from ProCityHub/hypercubeheartbeat `.github/scripts/guard_check.py`,
+which established this mechanism for the organization. Four blocks:
+
+1. Edits to frozen evidence artifacts listed in FROZEN_FILES.txt.
+2. Edits to governance source listed in GOVERNED_FILES.txt without an
+   explicit audit exception.
+3. Completion markers asserted inside documents rather than emitted by a run.
+4. Misuse of reserved empirical verdict language.
+
+The critical property, inherited from the original: both ledgers are read
+from the BASE branch, never the working tree. A pull request therefore
+cannot unfreeze a file by editing the ledger in the same pull request. This
+is what keeps the guard outside the set of things it guards.
+
+Vocabulary rule, unchanged across the organization:
+    PASS / FAIL              -> software test and check outcomes
+    SUPPORTED / NOT_SUPPORTED -> pre-registered empirical outcomes only
+The two are never mixed.
+
+Exit status 0 prints GUARD PASS. Any failure prints GUARD FAILED and exits 1.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+BASE_REF = os.environ.get("GITHUB_BASE_REF") or "main"
+FROZEN_LEDGER = "FROZEN_FILES.txt"
+GOVERNED_LEDGER = "GOVERNED_FILES.txt"
+AUDIT_EXCEPTION = re.compile(r"AUDIT-EXCEPTION:\s*\S+")
+
+
+# --------------------------------------------------------------------------
+# Git plumbing
+# --------------------------------------------------------------------------
+
+
+def run(cmd: list[str], *, check: bool = True) -> str:
+    result = subprocess.run(
+        cmd,
+        text=True,
+        capture_output=True,
+    )
+    if check and result.returncode != 0:
+        print(result.stdout)
+        print(result.stderr, file=sys.stderr)
+        raise SystemExit(result.returncode)
+    return result.stdout
+
+
+def diff_base_ref() -> str:
+    base = f"origin/{BASE_REF}"
+    run(["git", "fetch", "origin", BASE_REF, "--depth=100"], check=False)
+
+    probe = subprocess.run(
+        ["git", "merge-base", base, "HEAD"],
+        text=True,
+        capture_output=True,
+    )
+    if probe.returncode == 0 and probe.stdout.strip():
+        return probe.stdout.strip()
+
+    local = subprocess.run(
+        ["git", "merge-base", BASE_REF, "HEAD"],
+        text=True,
+        capture_output=True,
+    )
+    if local.returncode == 0 and local.stdout.strip():
+        return local.stdout.strip()
+
+    print(f"WARN: no merge base for {base}; using {base} directly")
+    return base
+
+
+def changed_files(base: str) -> list[str]:
+    output = run(["git", "diff", "--name-only", base, "HEAD"])
+    return [line.strip() for line in output.splitlines() if line.strip()]
+
+
+def added_lines_for(base: str, path: str) -> list[str]:
+    diff = run(["git", "diff", "-U0", base, "HEAD", "--", path], check=False)
+    lines = []
+    for line in diff.splitlines():
+        if line.startswith("+++") or line.startswith("---"):
+            continue
+        if line.startswith("+"):
+            lines.append(line[1:])
+    return lines
+
+
+def commit_messages(base: str) -> str:
+    return run(["git", "log", "--format=%B", f"{base}..HEAD"], check=False)
+
+
+# --------------------------------------------------------------------------
+# Ledgers
+# --------------------------------------------------------------------------
+
+
+def parse_ledger(text: str) -> set[str]:
+    entries = set()
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        entries.add(stripped)
+    return entries
+
+
+def read_base_ledger(name: str) -> set[str]:
+    """Read a ledger from the base branch, never the working tree."""
+
+    for ref in (f"origin/{BASE_REF}", BASE_REF):
+        result = subprocess.run(
+            ["git", "show", f"{ref}:{name}"],
+            text=True,
+            capture_output=True,
+        )
+        if result.returncode == 0:
+            return parse_ledger(result.stdout)
+    return set()
+
+
+def matches_ledger(path: str, ledger: set[str]) -> bool:
+    """Return True when ``path`` is covered by a ledger entry.
+
+    Entries ending in ``/`` cover a whole directory tree.
+    """
+
+    normalized = path.replace("\\", "/")
+    for entry in ledger:
+        if entry.endswith("/"):
+            if normalized.startswith(entry):
+                return True
+        elif normalized == entry:
+            return True
+    return False
+
+
+# --------------------------------------------------------------------------
+# Retracted formula (org-wide retraction R-003)
+# --------------------------------------------------------------------------
+
+SCALAR_PHI_PATTERNS = [
+    re.compile(
+        r"\b(?:score|s)\s*=\s*(?:phi|PHI|\u03c6)\s*[*\u00d7\u00b7]\s*"
+        r"(?:o|observer)\s*[*\u00d7\u00b7]\s*(?:a|actor)\s*[*\u00d7\u00b7]\s*"
+        r"(?:b|bridge|environment)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(?:phi|PHI|\u03c6)\s*[*\u00d7\u00b7]\s*(?:o|observer)\s*[*\u00d7\u00b7]\s*"
+        r"(?:a|actor)\s*[*\u00d7\u00b7]\s*(?:b|bridge|environment)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(?:o|observer)\s*[*\u00d7\u00b7]\s*(?:a|actor)\s*[*\u00d7\u00b7]\s*"
+        r"(?:b|bridge|environment)\s*[*\u00d7\u00b7]\s*(?:phi|PHI|\u03c6)\b",
+        re.IGNORECASE,
+    ),
+]
+
+
+# --------------------------------------------------------------------------
+# Claim boundary
+# --------------------------------------------------------------------------
+
+EMPIRICAL_SUPPORT_WORDS = re.compile(r"\b(SUPPORTED|NOT_SUPPORTED)\b")
+
+#: Markers that assert whole-system status. These are produced by a run or
+#: they are not true. A document may not assert them.
+RESERVED_COMPLETION_MARKERS = (
+    "THANOS_MODE_IMPLEMENTATION",
+    "STANDING_AUTHORITY",
+    "PERSISTENCE",
+    "REVOCATION",
+    "INTERNET_RESEARCH_INTERFACE",
+    "ISOLATED_SELF_MODIFICATION",
+    "AUTONOMOUS_REPAIR_LOOP",
+    "GITHUB_PROVIDER",
+    "GITHUB_CI_REPAIR",
+    "MERGE_WHEN_GREEN_LOGIC",
+    "AUTONOMOUS_GITHUB_WORKFLOW",
+    "AUTONOMOUS_MERGE_WHEN_GREEN",
+    "HEALTH_CHECK",
+    "RUNTIME_HEALTH_CHECK",
+    "ROLLBACK",
+    "HEARTBEAT",
+    "AUDITOR_IMMUNE_SYSTEM",
+    "AUDIT_INTEGRITY",
+    "PYTHON_39_COMPATIBILITY",
+    "FULL_TEST_SUITE",
+    "SECURITY_REVIEW",
+    "CAPABILITY_REGISTRY",
+)
+
+_ASSERTED_PASS = re.compile(
+    r"^\s*(?:[-*>]\s*)?(" + "|".join(RESERVED_COMPLETION_MARKERS) + r")\s*=\s*PASS\b"
+)
+
+#: Documents that may quote markers while describing the format itself.
+_MARKER_DOC_ALLOWLIST = (
+    "docs/GARVIS_THANOS_MODE.md",
+    "docs/GARVIS_AUTONOMOUS_UPGRADE_ARCHITECTURE.md",
+    "RETRACTIONS.md",
+    "GOVERNED_FILES.txt",
+    "FROZEN_FILES.txt",
+)
+
+_CLAIM_TEXT_SUFFIXES = {".md", ".txt", ".rst"}
+
+
+def is_document(path: str) -> bool:
+    return Path(path).suffix.lower() in _CLAIM_TEXT_SUFFIXES
+
+
+def is_claim_language_guard_path(path: str) -> bool:
+    """Return True for claim-controlled documents."""
+
+    normalized = path.replace("\\", "/")
+    name = Path(normalized).name.lower()
+
+    if normalized.startswith("claims/"):
+        return True
+    if name in {"claims.json", "preregistration.md", "outcomes.md"}:
+        return True
+    if normalized.startswith("docs/") and (
+        "claim" in name or "outcome" in name or "result" in name or "success" in name
+    ):
+        return True
+    return False
+
+
+def is_text_path(path: str) -> bool:
+    return Path(path).suffix.lower() in {
+        ".py",
+        ".md",
+        ".txt",
+        ".rst",
+        ".yml",
+        ".yaml",
+        ".json",
+        ".csv",
+        ".toml",
+    }
+
+
+# --------------------------------------------------------------------------
+# Main
+# --------------------------------------------------------------------------
+
+
+def main() -> None:
+    base = diff_base_ref()
+    changed = changed_files(base)
+
+    frozen = read_base_ledger(FROZEN_LEDGER)
+    governed = read_base_ledger(GOVERNED_LEDGER)
+    messages = commit_messages(base)
+    exception_claimed = bool(AUDIT_EXCEPTION.search(messages))
+
+    failures: list[str] = []
+    notices: list[str] = []
+
+    # 1. Frozen evidence artifacts. No override.
+    frozen_changes = sorted(p for p in changed if matches_ledger(p, frozen))
+    if frozen_changes:
+        failures.append(
+            "Frozen evidence artifacts changed:\n"
+            + "\n".join(f"  - {p}" for p in frozen_changes)
+            + "\nThese are frozen on "
+            + BASE_REF
+            + ". Editing the ledger in this pull request does not unfreeze them."
+        )
+
+    # 2. Governance source. Overridable only by an explicit, typed exception.
+    governed_changes = sorted(
+        p for p in changed if matches_ledger(p, governed) and p not in frozen_changes
+    )
+    if governed_changes:
+        listing = "\n".join(f"  - {p}" for p in governed_changes)
+        if exception_claimed:
+            notices.append(
+                "Governance source changed under a declared audit exception:\n"
+                + listing
+                + "\nCode-owner review is still required by branch protection."
+            )
+        else:
+            failures.append(
+                "Governance source changed without an audit exception:\n"
+                + listing
+                + "\nThese files define how changes are validated, so a cycle "
+                "cannot self-certify them.\nTo proceed, Adrien D. Thomas adds a "
+                "commit message line:\n  AUDIT-EXCEPTION: <reason>\n"
+                "This guard is the early signal; code-owner review on "
+                + BASE_REF
+                + " is the enforcement."
+            )
+
+    # 3 and 4. Line-level content checks.
+    for path in changed:
+        if not is_text_path(path) or not Path(path).exists():
+            continue
+
+        added = added_lines_for(base, path)
+
+        for line in added:
+            for pattern in SCALAR_PHI_PATTERNS:
+                if pattern.search(line):
+                    failures.append(
+                        f"{path}: retracted scalar-phi formula pattern added: {line.strip()}"
+                    )
+
+        if is_document(path) and path not in _MARKER_DOC_ALLOWLIST:
+            for line in added:
+                match = _ASSERTED_PASS.match(line)
+                if match:
+                    failures.append(
+                        f"{path}: completion marker {match.group(1)}=PASS asserted inside a "
+                        f"document.\n  {line.strip()}\n  This marker is produced by a run "
+                        "or it is not true. Cite the run, or record the honest "
+                        "state (NOT_IMPLEMENTED / FAIL)."
+                    )
+
+        if is_claim_language_guard_path(path):
+            for line in added:
+                if EMPIRICAL_SUPPORT_WORDS.search(line):
+                    failures.append(
+                        f"{path}: reserved empirical verdict language added inside "
+                        f"a claim-controlled document: {line.strip()}\n  SUPPORTED / "
+                        "NOT_SUPPORTED belong to pre-registered empirical "
+                        "outcomes only."
+                    )
+
+    for notice in notices:
+        print("GUARD NOTICE")
+        print()
+        print(notice)
+        print()
+
+    if failures:
+        print("GUARD FAILED")
+        print()
+        for failure in failures:
+            print(failure)
+            print()
+        raise SystemExit(1)
+
+    print("GUARD PASS")
+    print(f"Checked {len(changed)} changed file(s) against {BASE_REF}.")
+    print(f"Frozen entries: {len(frozen)}. Governed entries: {len(governed)}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/guard.yml
+++ b/.github/workflows/guard.yml
@@ -1,0 +1,28 @@
+name: Guard
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  guard:
+    name: Repository guard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # Full history: the guard needs a merge base with the target branch.
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run repository guard
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref || 'main' }}
+        run: python .github/scripts/guard_check.py

--- a/FROZEN_FILES.txt
+++ b/FROZEN_FILES.txt
@@ -1,0 +1,15 @@
+# GARVIS frozen evidence artifacts.
+#
+# Owner and final authority: Adrien D. Thomas (ProCityHub/GARVIS).
+#
+# Recorded outcomes and preregistered protocols. These do not change once
+# written. A result that can be edited after the fact is not a result.
+#
+# Unlike GOVERNED_FILES.txt there is no audit exception: a frozen artifact
+# is superseded by a new record and a RETRACTIONS.md entry, never rewritten.
+#
+# Read from the base branch. Editing this ledger in a pull request does not
+# unfreeze anything in that pull request.
+
+# (no frozen artifacts recorded yet -- add preregistrations and run
+#  outcomes here as they are produced)

--- a/GOVERNED_FILES.txt
+++ b/GOVERNED_FILES.txt
@@ -1,0 +1,34 @@
+# GARVIS governed source.
+#
+# Owner and final authority: Adrien D. Thomas (ProCityHub/GARVIS).
+#
+# These files define how a change is authorized and validated. A THANOS
+# cycle may research, patch, test, and open a pull request against them --
+# nothing here is permanently frozen, and GARVIS can genuinely improve its
+# own governance. What it cannot do is certify that change itself, because
+# the validation profile for these files IS these files.
+#
+# Enforcement order:
+#   1. .github/CODEOWNERS + branch protection  -- the wall (GitHub-side)
+#   2. this ledger + guard_check.py            -- the early signal (CI)
+#   3. thanos_mode.PROTECTED_PATHS             -- defense in depth (local)
+#
+# This ledger is read from the base branch. Editing it in a pull request
+# does not take effect for that pull request.
+#
+# To change a file listed here, add a commit message line:
+#   AUDIT-EXCEPTION: <reason>
+# and obtain code-owner review.
+
+# Authorization and gating
+src/garvis/thanos_mode.py
+src/garvis/stage_gate.py
+src/garvis/stage_gate_store.py
+src/garvis/upgrade_cycle.py
+src/garvis/github_maintenance.py
+
+# Evidence integrity
+src/garvis/upgrade_research.py
+
+# The guard itself, and everything that runs it
+.github/

--- a/RETRACTIONS.md
+++ b/RETRACTIONS.md
@@ -1,0 +1,56 @@
+# GARVIS Retractions Ledger
+
+Owner and final authority: Adrien D. Thomas (ProCityHub/GARVIS).
+
+A retraction is a public, permanent record that something previously stated
+in this repository was wrong. Entries are appended, never edited or removed.
+Superseding a retraction requires a new entry, not a rewrite.
+
+This ledger exists because the alternative is silent correction, and a claim
+that can be quietly withdrawn was never a claim.
+
+## Vocabulary
+
+| Terms | Reserved for |
+|---|---|
+| `PASS` / `FAIL` | software test and check outcomes |
+| `SUPPORTED` / `NOT_SUPPORTED` | pre-registered empirical outcomes only |
+
+These are never mixed. `.github/scripts/guard_check.py` enforces this in CI.
+
+## Entry format
+
+```
+### R-XXX  <short title>
+- **Status:** RETRACTED
+- **Date:** YYYY-MM-DD
+- **Retracted claim:** what was asserted
+- **Why it was wrong:** the specific defect
+- **Superseded by:** the correct statement, or NONE
+- **Enforcement:** what now prevents recurrence
+```
+
+---
+
+## Inherited organization-wide retractions
+
+### R-003  Scalar Lattice Law formula
+- **Status:** RETRACTED
+- **Origin:** ProCityHub/hypercubeheartbeat, applies organization-wide
+- **Retracted claim:** `C = O x A x B x phi` (phi as a scalar multiplier)
+- **Why it was wrong:** the scalar form was not the tested formulation and
+  did not survive self-audit
+- **Superseded by:** `C = O^1 . A^(1/phi) . B^(1/phi^2)`, with phi in the
+  exponents
+- **Enforcement:** `SCALAR_PHI_PATTERNS` in
+  `.github/scripts/guard_check.py` fails CI if the pattern is reintroduced
+
+---
+
+## GARVIS retractions
+
+None recorded.
+
+This section is empty because no GARVIS claim has yet been found false --
+not because none can be. When one is, it goes here before anything else
+proceeds.

--- a/tests/garvis/test_guard_check.py
+++ b/tests/garvis/test_guard_check.py
@@ -69,7 +69,7 @@ def make_repo(tmp_path: Path) -> Path:
     return repo
 
 
-def commit_change(repo: Path, files: dict, message: str = "change") -> None:
+def commit_change(repo: Path, files: dict[str, str], message: str = "change") -> None:
     if _git(repo, "branch", "--show-current").strip() == "main":
         _git(repo, "checkout", "-q", "-b", "feature")
     for path, text in files.items():
@@ -78,7 +78,7 @@ def commit_change(repo: Path, files: dict, message: str = "change") -> None:
     _git(repo, "commit", "-q", "-m", message)
 
 
-def run_guard(repo: Path):
+def run_guard(repo: Path) -> subprocess.CompletedProcess[str]:
     # Inherit the real environment. Hardcoding PATH breaks on Termux, where
     # git lives under /data/data/com.termux/files/usr/bin rather than /usr/bin.
     env = dict(os.environ)

--- a/tests/garvis/test_guard_check.py
+++ b/tests/garvis/test_guard_check.py
@@ -1,0 +1,320 @@
+"""Tests for `.github/scripts/guard_check.py`.
+
+The guard reads real git history, so these tests build real repositories
+rather than mocking git. Each case creates a `main` branch, branches off it,
+commits a change, and runs the guard exactly as CI does.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GUARD = REPO_ROOT / ".github" / "scripts" / "guard_check.py"
+
+pytestmark = pytest.mark.skipif(
+    not GUARD.is_file() or shutil.which("git") is None,
+    reason="guard script or git unavailable",
+)
+
+BASE_GOVERNED = """# governed
+src/garvis/thanos_mode.py
+src/garvis/stage_gate.py
+.github/
+"""
+
+BASE_FROZEN = """# frozen
+results/run_001.json
+"""
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def _write(repo: Path, path: str, text: str) -> None:
+    target = repo / path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(text, encoding="utf-8")
+
+
+def make_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "adrien@example.invalid")
+    _git(repo, "config", "user.name", "Adrien D. Thomas")
+
+    _write(repo, "GOVERNED_FILES.txt", BASE_GOVERNED)
+    _write(repo, "FROZEN_FILES.txt", BASE_FROZEN)
+    _write(repo, "src/garvis/thanos_mode.py", "OWNER = 'Adrien D. Thomas'\n")
+    _write(repo, "src/garvis/assistant.py", "VALUE = 1\n")
+    _write(repo, "results/run_001.json", '{"outcome": "NOT_SUPPORTED"}\n')
+    _write(repo, "docs/notes.md", "# Notes\n")
+    _write(repo, "claims/CLAIMS.json", "{}\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "base")
+    return repo
+
+
+def commit_change(repo: Path, files: dict, message: str = "change") -> None:
+    if _git(repo, "branch", "--show-current").strip() == "main":
+        _git(repo, "checkout", "-q", "-b", "feature")
+    for path, text in files.items():
+        _write(repo, path, text)
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", message)
+
+
+def run_guard(repo: Path):
+    # Inherit the real environment. Hardcoding PATH breaks on Termux, where
+    # git lives under /data/data/com.termux/files/usr/bin rather than /usr/bin.
+    env = dict(os.environ)
+    env["GITHUB_BASE_REF"] = "main"
+    return subprocess.run(
+        [sys.executable, str(GUARD)],
+        cwd=str(repo),
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+
+
+# --------------------------------------------------------------------------
+# Baseline
+# --------------------------------------------------------------------------
+
+
+def test_ordinary_change_passes(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    commit_change(repo, {"src/garvis/assistant.py": "VALUE = 2\n"})
+    result = run_guard(repo)
+    assert "GUARD PASS" in result.stdout
+    assert result.returncode == 0
+
+
+def test_new_ordinary_file_passes(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    commit_change(repo, {"src/garvis/repair_engine.py": "def repair():\n    pass\n"})
+    assert run_guard(repo).returncode == 0
+
+
+# --------------------------------------------------------------------------
+# Governed source
+# --------------------------------------------------------------------------
+
+
+def test_governance_change_fails_without_exception(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    commit_change(repo, {"src/garvis/thanos_mode.py": "OWNER = 'someone else'\n"})
+    result = run_guard(repo)
+    assert result.returncode == 1
+    assert "GUARD FAILED" in result.stdout
+    assert "thanos_mode.py" in result.stdout
+    assert "AUDIT-EXCEPTION" in result.stdout
+
+
+def test_governance_change_passes_with_declared_exception(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    commit_change(
+        repo,
+        {"src/garvis/thanos_mode.py": "OWNER = 'Adrien D. Thomas'  # tuned\n"},
+        message="chore: adjust\n\nAUDIT-EXCEPTION: reviewed governance tweak",
+    )
+    result = run_guard(repo)
+    assert result.returncode == 0
+    assert "GUARD NOTICE" in result.stdout
+    assert "code-owner review" in result.stdout.lower()
+
+
+def test_directory_ledger_entry_covers_subtree(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    commit_change(repo, {".github/workflows/tests.yml": "name: Tests\n"})
+    result = run_guard(repo)
+    assert result.returncode == 1
+    assert ".github/workflows/tests.yml" in result.stdout
+
+
+# --------------------------------------------------------------------------
+# The closure property: a PR cannot unfreeze itself
+# --------------------------------------------------------------------------
+
+
+def test_pr_cannot_ungovern_a_file_it_also_edits(tmp_path: Path) -> None:
+    """The load-bearing test.
+
+    A cycle removes thanos_mode.py from the governed ledger AND edits it in
+    the same pull request. The ledger is read from the base branch, so the
+    removal has no effect on this pull request.
+    """
+
+    repo = make_repo(tmp_path)
+    commit_change(
+        repo,
+        {
+            "GOVERNED_FILES.txt": "# governed\nsrc/garvis/stage_gate.py\n.github/\n",
+            "src/garvis/thanos_mode.py": "OWNER = 'self-approved'\n",
+        },
+    )
+    result = run_guard(repo)
+    assert result.returncode == 1
+    assert "thanos_mode.py" in result.stdout
+    assert "does not unfreeze" in result.stdout or "audit exception" in result.stdout
+
+
+def test_pr_cannot_empty_the_governed_ledger(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    commit_change(
+        repo,
+        {
+            "GOVERNED_FILES.txt": "# emptied\n",
+            "src/garvis/stage_gate.py": "BYPASS = True\n",
+        },
+    )
+    assert run_guard(repo).returncode == 1
+
+
+# --------------------------------------------------------------------------
+# Frozen artifacts
+# --------------------------------------------------------------------------
+
+
+def test_frozen_artifact_change_fails(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    commit_change(repo, {"results/run_001.json": '{"outcome": "SUPPORTED"}\n'})
+    result = run_guard(repo)
+    assert result.returncode == 1
+    assert "Frozen evidence artifacts changed" in result.stdout
+
+
+def test_frozen_artifact_has_no_audit_override(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    commit_change(
+        repo,
+        {"results/run_001.json": '{"outcome": "SUPPORTED"}\n'},
+        message="fix\n\nAUDIT-EXCEPTION: I would like this result to be different",
+    )
+    assert run_guard(repo).returncode == 1
+
+
+# --------------------------------------------------------------------------
+# Claim boundary: markers must come from a run
+# --------------------------------------------------------------------------
+
+
+def test_completion_marker_asserted_in_document_fails(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    commit_change(
+        repo,
+        {"docs/status.md": "# Status\n\nFULL_TEST_SUITE=PASS\nROLLBACK=PASS\n"},
+    )
+    result = run_guard(repo)
+    assert result.returncode == 1
+    assert "asserted inside a" in result.stdout
+    assert "FULL_TEST_SUITE" in result.stdout
+
+
+def test_marker_in_bullet_list_is_still_caught(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    commit_change(repo, {"docs/status.md": "# Status\n\n- HEARTBEAT=PASS\n"})
+    assert run_guard(repo).returncode == 1
+
+
+def test_honest_not_implemented_marker_passes(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    commit_change(
+        repo,
+        {"docs/status.md": "# Status\n\nROLLBACK=NOT_IMPLEMENTED\nHEARTBEAT=FAIL\n"},
+    )
+    assert run_guard(repo).returncode == 0
+
+
+def test_marker_in_source_code_is_not_a_document_assertion(tmp_path: Path) -> None:
+    """render_status builds these strings; that is code, not a claim."""
+
+    repo = make_repo(tmp_path)
+    commit_change(
+        repo,
+        {"src/garvis/render.py": 'LINE = "FULL_TEST_SUITE=PASS"\n'},
+    )
+    assert run_guard(repo).returncode == 0
+
+
+def test_allowlisted_documentation_may_describe_the_format(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    commit_change(
+        repo,
+        {"RETRACTIONS.md": "# Retractions\n\nFULL_TEST_SUITE=PASS is a run marker.\n"},
+    )
+    assert run_guard(repo).returncode == 0
+
+
+# --------------------------------------------------------------------------
+# Vocabulary discipline
+# --------------------------------------------------------------------------
+
+
+def test_empirical_verdict_in_claims_document_fails(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    commit_change(repo, {"claims/CLAIMS.json": '{"lattice": "SUPPORTED"}\n'})
+    result = run_guard(repo)
+    assert result.returncode == 1
+    assert "reserved empirical verdict" in result.stdout
+
+
+def test_empirical_verdict_in_ordinary_document_passes(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    commit_change(
+        repo,
+        {"docs/notes.md": "# Notes\n\nWe use SUPPORTED only for preregistered runs.\n"},
+    )
+    assert run_guard(repo).returncode == 0
+
+
+# --------------------------------------------------------------------------
+# Retracted formula
+# --------------------------------------------------------------------------
+
+
+# The retracted scalar formula is assembled from fragments at runtime.
+# No source line here contains the pattern, so the guard's own test data
+# cannot trip the guard -- and no allowlist exception is needed, which
+# means nobody can smuggle the retracted formula in via a test file.
+_PHI = "phi"
+_MUL = " * "
+
+SCALAR_PHI_CASES = (
+    "score = " + _MUL.join((_PHI, "o", "a", "b")),
+    "C = " + _MUL.join((_PHI.upper(), "observer", "actor", "bridge")),
+    "value = " + _MUL.join(("observer", "actor", "environment", _PHI)),
+)
+
+
+@pytest.mark.parametrize("line", SCALAR_PHI_CASES)
+def test_retracted_scalar_phi_formula_is_blocked(tmp_path: Path, line: str) -> None:
+    repo = make_repo(tmp_path)
+    commit_change(repo, {"docs/notes.md": f"# Notes\n\n{line}\n"})
+    result = run_guard(repo)
+    assert result.returncode == 1
+    assert "scalar-phi" in result.stdout
+
+
+def test_canonical_exponent_formula_is_allowed(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    commit_change(
+        repo,
+        {"docs/notes.md": "# Notes\n\nC = O^1 . A^(1/phi) . B^(1/phi^2)\n"},
+    )
+    assert run_guard(repo).returncode == 0


### PR DESCRIPTION
Ports the guard from ProCityHub/hypercubeheartbeat.

Ledgers are read from the base branch: a pull request cannot ungovern a file it also edits.

- .github/scripts/guard_check.py
- .github/workflows/guard.yml
- .github/CODEOWNERS
- FROZEN_FILES.txt, GOVERNED_FILES.txt
- RETRACTIONS.md (R-003 inherited)
- tests/garvis/test_guard_check.py (20 tests)

This PR touches governed paths, so it routes to code-owner review by design.

Owner: Adrien D. Thomas

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated repository safeguards for pull requests and pushes to `main`.
  * Added ledgers for frozen artifacts, governed files, and permanent retractions.
  * Added checks for unauthorized governance changes, frozen-file edits, retracted formulas, unsupported completion markers, and restricted verdict language.
  * Added code ownership assignments for governance-related files.

* **Tests**
  * Added comprehensive coverage for guard behavior, exceptions, ledger protections, and content validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->