### PR TITLE
feat(provider): add xAI Grok as a first-class provider

### DIFF
--- a/src/garvis/provider_bridge.py
+++ b/src/garvis/provider_bridge.py
@@ -46,7 +46,12 @@ class ProviderSpec:
 
 
 _PROVIDER_SPECS = {
+    # groq/ and grok/ are different companies and are deliberately adjacent
+    # here so the one-letter difference is visible at the point of change.
+    # groq/ -> Groq, inference hardware serving open models.
+    # grok/ -> xAI, the Grok model family.
     "groq": ProviderSpec("groq", "groq/", "https://api.groq.com/openai/v1", "GROQ_API_KEY"),
+    "grok": ProviderSpec("grok", "grok/", "https://api.x.ai/v1", "XAI_API_KEY"),
     "openrouter": ProviderSpec(
         "openrouter", "openrouter/", "https://openrouter.ai/api/v1", "OPENROUTER_API_KEY"
     ),

--- a/tests/garvis/test_provider_bridge.py
+++ b/tests/garvis/test_provider_bridge.py
@@ -40,6 +40,7 @@ def _capture(monkeypatch):
     ("model", "provider"),
     [
         ("groq/openai/gpt-oss-20b", "groq"),
+        ("grok/grok-4.5", "grok"),
         ("openrouter/openrouter/free", "openrouter"),
         ("compatible/vendor/model", "compatible"),
     ],
@@ -100,3 +101,46 @@ def test_cli_rejects_unconfigured_openrouter(monkeypatch) -> None:
     error = _check_configuration("openrouter/openrouter/free")
     assert error is not None
     assert "OPENROUTER_API_KEY" in error
+
+
+def test_grok_configures_existing_openai_sdk(monkeypatch) -> None:
+    monkeypatch.setenv("XAI_API_KEY", "test-xai-key")
+    captured = _capture(monkeypatch)
+    model = provider_bridge.configure_openai_compatible("grok/grok-4.5")
+    assert model == "grok-4.5"
+    assert captured["client"]["base_url"] == "https://api.x.ai/v1"
+    assert captured["client"]["api_key"] == "test-xai-key"
+    assert captured["use_for_tracing"] is False
+    assert captured["api"] == "chat_completions"
+    assert captured["tracing_disabled"] is True
+
+
+def test_grok_and_groq_do_not_cross_match() -> None:
+    """One letter apart, two different companies. They must not collide."""
+
+    assert provider_bridge.provider_name("grok/grok-4.5") == "grok"
+    assert provider_bridge.provider_name("groq/openai/gpt-oss-20b") == "groq"
+    assert provider_bridge.required_api_key_environment("grok/grok-4.5") == "XAI_API_KEY"
+    assert provider_bridge.required_api_key_environment("groq/openai/gpt-oss-20b") == "GROQ_API_KEY"
+
+
+def test_grok_requires_a_model_identifier(monkeypatch) -> None:
+    """An empty model id is still claimed by grok/, so the error is specific."""
+
+    monkeypatch.setenv("XAI_API_KEY", "test-xai-key")
+    assert provider_bridge.is_openai_compatible_model("grok/") is True
+    with pytest.raises(provider_bridge.ProviderConfigurationError):
+        provider_bridge.configure_openai_compatible("grok/")
+
+
+def test_cli_rejects_unconfigured_grok(monkeypatch) -> None:
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+    error = _check_configuration("grok/grok-4.5")
+    assert error is not None
+    assert "XAI_API_KEY" in error
+
+
+def test_cli_accepts_configured_grok(monkeypatch) -> None:
+    monkeypatch.setenv("XAI_API_KEY", "test-key")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    assert _check_configuration("grok/grok-4.5") is None


### PR DESCRIPTION
Adds grok/ -> https://api.x.ai/v1 using XAI_API_KEY.

Grok was already reachable through compatible/ and openrouter/. This makes it
a named provider so no extra environment variables are needed.

groq/ and grok/ are different companies one letter apart, so they sit adjacent
with a comment and a cross-match regression test.

Owner: Adrien D. Thomas