### PR TITLE
feat(research): connect THANOS research to Hypercube governance

### DIFF
--- a/src/garvis/capability_runtime.py
+++ b/src/garvis/capability_runtime.py
@@ -15,6 +15,17 @@ from .capability_broker import (
     has_explicit_network_authorization,
 )
 from .internet_research import InternetResearchClient, ResearchError, ResearchReport
+from .research_governance import (
+    govern_research_answer,
+    render_governance_status,
+    research_verification_contract,
+)
+from .thanos_mode import (
+    ThanosAction,
+    ThanosAuthorizationStore,
+    ThanosError,
+    permits,
+)
 from .local_file_access import (
     LocalAccessError,
     LocalAccessRequest,
@@ -48,7 +59,7 @@ class CapabilityRuntimeConfig:
     @classmethod
     def from_environment(cls) -> CapabilityRuntimeConfig:
         mode = os.getenv("GARVIS_NETWORK_MODE", "approval").strip().casefold()
-        return cls(mode if mode in {"off", "approval"} else "approval")
+        return cls(mode if mode in {"off", "approval", "thanos"} else "approval")
 
 
 class CapabilityAwareRuntime:
@@ -60,6 +71,7 @@ class CapabilityAwareRuntime:
         local_access_store: LocalFileAccessStore | None = None,
         researcher: Researcher | None = None,
         config: CapabilityRuntimeConfig | None = None,
+        thanos_store: ThanosAuthorizationStore | None = None,
         session_id: str = "default",
     ) -> None:
         self.local_runtime = local_runtime
@@ -67,11 +79,47 @@ class CapabilityAwareRuntime:
         self.local_access_store = local_access_store or LocalFileAccessStore()
         self.researcher = researcher or InternetResearchClient()
         self.config = config or CapabilityRuntimeConfig.from_environment()
+        default_thanos_store = Path(
+            os.getenv(
+                "GARVIS_THANOS_STORE",
+                str(
+                    Path.home()
+                    / ".garvis"
+                    / "thanos"
+                    / "authorization.json"
+                ),
+            )
+        ).expanduser()
+        self.thanos_store = (
+            thanos_store
+            or ThanosAuthorizationStore(
+                default_thanos_store
+            )
+        )
         self.session_id = session_id
 
     def close(self) -> None:
         self.approval_store.close()
         self.local_access_store.close()
+
+    def _thanos_research_authorized(self) -> tuple[bool, str]:
+        """Verify standing THANOS authority before internet research."""
+
+        try:
+            authorization = self.thanos_store.load()
+
+            if authorization is None:
+                return False, "THANOS standing authorization is absent"
+
+            permits(
+                authorization,
+                ThanosAction.RESEARCH,
+            )
+
+        except ThanosError as exc:
+            return False, str(exc)
+
+        return True, ""
 
     def _remember(self, request: str, answer: str, report: ResearchReport) -> None:
         try:
@@ -103,19 +151,59 @@ class CapabilityAwareRuntime:
         except Exception:
             return
 
-    def _execute_research(self, request: ApprovalRequest) -> str:
+    def _execute_research(
+        self,
+        request: ApprovalRequest,
+        *,
+        governed: bool = False,
+    ) -> str:
         self.approval_store.audit(
             "network_research_started",
             session_id=self.session_id,
             request_id=request.request_id,
-            detail={"query": request.research_query},
+            detail={
+                "query": request.research_query,
+                "governed": governed,
+            },
         )
+
+        governance = None
+
         try:
-            report = self.researcher.research(request.research_query)
+            report = self.researcher.research(
+                request.research_query
+            )
+
+            model_request = (
+                research_verification_contract(
+                    request.original_request
+                )
+                if governed
+                else request.original_request
+            )
+
             answer = self.local_runtime.respond(
-                request.original_request,
+                model_request,
                 external_context=report.render_context(),
             )
+
+            if governed:
+                answer, governance = govern_research_answer(
+                    request.original_request,
+                    answer,
+                    report,
+                    self.local_runtime.repository_root,
+                    session_id=self.session_id,
+                )
+
+                answer = (
+                    answer
+                    + "\n\n"
+                    + render_governance_status(
+                        governance
+                    )
+                )
+
         except ResearchError as exc:
             self.approval_store.audit(
                 "network_research_failed",
@@ -123,7 +211,9 @@ class CapabilityAwareRuntime:
                 request_id=request.request_id,
                 detail={"error": str(exc)},
             )
-            return f"GARVIS research error: {exc}"
+
+            return "GARVIS research error: " + str(exc)
+
         except Exception as exc:
             self.approval_store.audit(
                 "network_research_failed",
@@ -131,18 +221,34 @@ class CapabilityAwareRuntime:
                 request_id=request.request_id,
                 detail={"error": str(exc)},
             )
-            return f"GARVIS research failed safely: {exc}"
-        self._remember(request.original_request, answer, report)
+
+            return "GARVIS research failed safely: " + str(exc)
+
+        self._remember(
+            request.original_request,
+            answer,
+            report,
+        )
+
+        detail = {
+            "provider": report.provider,
+            "sources": len(report.sources),
+            "distinct_domains": report.distinct_domains,
+            "governed": governed,
+        }
+
+        if governance is not None:
+            detail["hypercube_acceptance"] = (
+                governance["hypercube_acceptance"]
+            )
+
         self.approval_store.audit(
             "network_research_completed",
             session_id=self.session_id,
             request_id=request.request_id,
-            detail={
-                "provider": report.provider,
-                "sources": len(report.sources),
-                "distinct_domains": report.distinct_domains,
-            },
+            detail=detail,
         )
+
         return answer
 
     def _execute_local_access(self, request: LocalAccessRequest) -> str:
@@ -228,17 +334,74 @@ class CapabilityAwareRuntime:
 
         if not appears_to_require_research(message):
             return self.local_runtime.respond(message)
+
         if self.config.network_mode == "off":
             return "Internet research is disabled. No network request was made."
+
+        if self.config.network_mode == "thanos":
+            allowed, reason = self._thanos_research_authorized()
+
+            if not allowed:
+                self.approval_store.audit(
+                    "standing_authority_rejected",
+                    session_id=self.session_id,
+                    detail={"reason": reason},
+                )
+
+                return (
+                    "GARVIS standing internet research unavailable: "
+                    + reason
+                )
+
+            request = self.approval_store.create(
+                message,
+                extract_research_query(message),
+                session_id=self.session_id,
+            )
+
+            resolution = self.approval_store.resolve(
+                "approve",
+                session_id=self.session_id,
+            )
+
+            if resolution is None:
+                return (
+                    "GARVIS could not activate standing research authority."
+                )
+
+            self.approval_store.audit(
+                "standing_authority_used",
+                session_id=self.session_id,
+                request_id=resolution.request.request_id,
+                detail={
+                    "action": ThanosAction.RESEARCH.value
+                },
+            )
+
+            return self._execute_research(
+                resolution.request,
+                governed=True,
+            )
 
         request = self.approval_store.create(
             message,
             extract_research_query(message),
             session_id=self.session_id,
         )
+
         if has_explicit_network_authorization(message):
-            resolution = self.approval_store.resolve("approve", session_id=self.session_id)
+            resolution = self.approval_store.resolve(
+                "approve",
+                session_id=self.session_id,
+            )
+
             if resolution is None:
-                return "GARVIS could not record the one-time approval safely."
-            return self._execute_research(resolution.request)
+                return (
+                    "GARVIS could not record the one-time approval safely."
+                )
+
+            return self._execute_research(
+                resolution.request
+            )
+
         return request.render()

--- a/src/garvis/cli.py
+++ b/src/garvis/cli.py
@@ -121,11 +121,34 @@ def _build_local_runtime(session_id: str = "default") -> CapabilityAwareRuntime:
     from .local_language_runtime import LocalLanguageRuntime, LocalRuntimeConfig
 
     normalized_session_id = session_id.strip() or "default"
+
     local = LocalLanguageRuntime(
         LocalRuntimeConfig.from_environment(Path.cwd()),
         session_id=normalized_session_id,
     )
-    return CapabilityAwareRuntime(local, session_id=normalized_session_id)
+
+    previous_network_mode = os.environ.get(
+        "GARVIS_NETWORK_MODE"
+    )
+
+    if previous_network_mode is None:
+        os.environ["GARVIS_NETWORK_MODE"] = "thanos"
+
+    try:
+        return CapabilityAwareRuntime(
+            local,
+            session_id=normalized_session_id,
+        )
+    finally:
+        if previous_network_mode is None:
+            os.environ.pop(
+                "GARVIS_NETWORK_MODE",
+                None,
+            )
+        else:
+            os.environ["GARVIS_NETWORK_MODE"] = (
+                previous_network_mode
+            )
 
 
 def _configure_local_memory(args: argparse.Namespace) -> None:

--- a/src/garvis/internet_research.py
+++ b/src/garvis/internet_research.py
@@ -7,6 +7,7 @@ import ipaddress
 import json
 import re
 import socket
+import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from html.parser import HTMLParser
 from urllib.parse import parse_qs, quote_plus, unquote, urljoin, urlparse
@@ -101,6 +102,60 @@ def _unpack_ddg(url: str) -> str:
     parsed = urlparse(html.unescape(url))
     query = parse_qs(parsed.query)
     return unquote(query["uddg"][0]) if query.get("uddg") else html.unescape(url)
+
+
+_OFFICIAL_SOURCE_CATALOG = (
+    (
+        ("python", "asyncio"),
+        "Python asyncio documentation",
+        "https://docs.python.org/3/library/asyncio.html",
+    ),
+    (
+        ("python", "subprocess"),
+        "Python subprocess documentation",
+        "https://docs.python.org/3/library/subprocess.html",
+    ),
+    (
+        ("python", "logging"),
+        "Python logging documentation",
+        "https://docs.python.org/3/library/logging.html",
+    ),
+    (
+        ("python", "concurrent"),
+        "Python concurrent.futures documentation",
+        "https://docs.python.org/3/library/concurrent.futures.html",
+    ),
+    (
+        ("github", "actions"),
+        "GitHub Actions documentation",
+        "https://docs.github.com/en/actions",
+    ),
+    (
+        ("git", "worktree"),
+        "Git worktree documentation",
+        "https://git-scm.com/docs/git-worktree",
+    ),
+    (
+        ("pytest",),
+        "pytest documentation",
+        "https://docs.pytest.org/en/stable/",
+    ),
+    (
+        ("mypy",),
+        "mypy documentation",
+        "https://mypy.readthedocs.io/en/stable/",
+    ),
+    (
+        ("pydantic",),
+        "Pydantic documentation",
+        "https://docs.pydantic.dev/latest/",
+    ),
+    (
+        ("model context protocol",),
+        "Model Context Protocol documentation",
+        "https://modelcontextprotocol.io/docs",
+    ),
+)
 
 
 def _validate_public_url(url: str) -> None:
@@ -230,6 +285,292 @@ class InternetResearchClient:
             if isinstance(source_url, str)
         ]
 
+    def _official_sources(self, query: str) -> list[ResearchSource]:
+        """Return known official documentation relevant to the actual query."""
+
+        lowered = query.casefold()
+        results: list[ResearchSource] = []
+
+        for required, title, url in _OFFICIAL_SOURCE_CATALOG:
+            if not all(term in lowered for term in required):
+                continue
+
+            results.append(
+                ResearchSource(
+                    title=title,
+                    url=url,
+                    domain=_domain(url),
+                    snippet="Official documentation relevant to the research query.",
+                )
+            )
+
+            if len(results) >= self.policy.max_results:
+                break
+
+        return results
+
+    def _duckduckgo_lite(self, query: str) -> list[ResearchSource]:
+        """Use DuckDuckGo's lite interface as a second parser/search path."""
+
+        body, _, _ = self._get(
+            "https://lite.duckduckgo.com/lite/?q="
+            f"{quote_plus(query)}"
+        )
+
+        text = body.decode(
+            "utf-8",
+            errors="replace",
+        )
+
+        links = re.findall(
+            r'<a[^>]+href=["\']([^"\']+)["\'][^>]*>(.*?)</a>',
+            text,
+            re.I | re.S,
+        )
+
+        results: list[ResearchSource] = []
+        seen: set[str] = set()
+
+        for raw_url, raw_title in links:
+            url = _unpack_ddg(raw_url)
+
+            if not urlparse(url).scheme:
+                url = urljoin(
+                    "https://lite.duckduckgo.com/",
+                    url,
+                )
+                url = _unpack_ddg(url)
+
+            domain = _domain(url)
+
+            if (
+                not domain
+                or domain.endswith("duckduckgo.com")
+                or url in seen
+            ):
+                continue
+
+            try:
+                _validate_public_url(url)
+            except ResearchError:
+                continue
+
+            seen.add(url)
+
+            results.append(
+                ResearchSource(
+                    title=_visible(raw_title) or domain,
+                    url=url,
+                    domain=domain,
+                    snippet="",
+                )
+            )
+
+            if len(results) >= self.policy.max_results:
+                break
+
+        return results
+
+    def _github(self, query: str) -> list[ResearchSource]:
+        """Search public GitHub repositories through GitHub's public API."""
+
+        terms = re.findall(
+            r"[A-Za-z0-9_.+-]{3,}",
+            query,
+        )
+
+        search_query = " ".join(
+            terms[:12]
+        ).strip()
+
+        if not search_query:
+            return []
+
+        url = (
+            "https://api.github.com/search/repositories?"
+            f"q={quote_plus(search_query[:180])}"
+            "&sort=updated&order=desc"
+            f"&per_page={self.policy.max_results}"
+        )
+
+        body, _, _ = self._get(url)
+
+        data = json.loads(
+            body.decode(
+                "utf-8",
+                errors="replace",
+            )
+        )
+
+        items = data.get("items", [])
+
+        if not isinstance(items, list):
+            return []
+
+        results: list[ResearchSource] = []
+
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+
+            api_url = str(
+                item.get("url") or ""
+            ).strip()
+
+            if not api_url:
+                continue
+
+            try:
+                _validate_public_url(api_url)
+            except ResearchError:
+                continue
+
+            description = str(
+                item.get("description") or ""
+            )
+
+            metadata = {
+                "full_name": item.get("full_name"),
+                "description": item.get("description"),
+                "language": item.get("language"),
+                "updated_at": item.get("updated_at"),
+                "pushed_at": item.get("pushed_at"),
+                "stargazers_count": item.get(
+                    "stargazers_count"
+                ),
+                "html_url": item.get("html_url"),
+            }
+
+            results.append(
+                ResearchSource(
+                    title=str(
+                        item.get("full_name")
+                        or item.get("name")
+                        or "GitHub repository"
+                    ),
+                    url=api_url,
+                    domain=_domain(api_url),
+                    snippet=description[:500],
+                    excerpt=json.dumps(
+                        metadata,
+                        sort_keys=True,
+                    )[: self.policy.max_excerpt_chars],
+                )
+            )
+
+            if len(results) >= self.policy.max_results:
+                break
+
+        return results
+
+    def _arxiv(self, query: str) -> list[ResearchSource]:
+        """Search arXiv for papers related to the actual research query."""
+
+        terms = re.findall(
+            r"[A-Za-z0-9_-]{3,}",
+            query,
+        )
+
+        compact = " ".join(
+            terms[:16]
+        ).strip()
+
+        if not compact:
+            return []
+
+        search_expression = quote_plus(
+            "all:" + compact
+        )
+
+        url = (
+            "https://export.arxiv.org/api/query?"
+            f"search_query={search_expression}"
+            "&start=0"
+            f"&max_results={self.policy.max_results}"
+        )
+
+        body, _, _ = self._get(url)
+
+        root = ET.fromstring(body)
+
+        namespace = {
+            "atom": "http://www.w3.org/2005/Atom"
+        }
+
+        results: list[ResearchSource] = []
+
+        for entry in root.findall(
+            "atom:entry",
+            namespace,
+        ):
+            title = " ".join(
+                (
+                    entry.findtext(
+                        "atom:title",
+                        default="",
+                        namespaces=namespace,
+                    )
+                    or ""
+                ).split()
+            )
+
+            summary = " ".join(
+                (
+                    entry.findtext(
+                        "atom:summary",
+                        default="",
+                        namespaces=namespace,
+                    )
+                    or ""
+                ).split()
+            )
+
+            source_url = (
+                entry.findtext(
+                    "atom:id",
+                    default="",
+                    namespaces=namespace,
+                )
+                or ""
+            ).strip()
+
+            if source_url.startswith(
+                "http://arxiv.org/"
+            ):
+                source_url = (
+                    "https://arxiv.org/"
+                    + source_url[
+                        len("http://arxiv.org/"):
+                    ]
+                )
+
+            if not source_url:
+                continue
+
+            try:
+                _validate_public_url(
+                    source_url
+                )
+            except ResearchError:
+                continue
+
+            results.append(
+                ResearchSource(
+                    title=title or "arXiv paper",
+                    url=source_url,
+                    domain=_domain(source_url),
+                    snippet=summary[:500],
+                    excerpt=summary[
+                        : self.policy.max_excerpt_chars
+                    ],
+                )
+            )
+
+            if len(results) >= self.policy.max_results:
+                break
+
+        return results
+
     def _excerpt(self, source: ResearchSource) -> ResearchSource:
         try:
             body, final_url, content_type = self._get(source.url)
@@ -248,27 +589,115 @@ class InternetResearchClient:
         )
 
     def research(self, query: str) -> ResearchReport:
-        clean = " ".join(query.strip().split())
+        clean = " ".join(
+            query.strip().split()
+        )
+
         if not clean:
-            raise ResearchError("Research query must not be empty")
-        provider = "duckduckgo_html"
-        try:
-            sources = self._duckduckgo(clean)
-        except (ResearchError, requests.RequestException, ValueError):
-            sources = []
-        if not sources:
-            provider = "wikipedia_opensearch"
+            raise ResearchError(
+                "Research query must not be empty"
+            )
+
+        sources: list[ResearchSource] = []
+        seen: set[str] = set()
+        providers: list[str] = []
+
+        def add(
+            provider: str,
+            candidates: list[ResearchSource],
+        ) -> None:
+            added = False
+
+            for source in candidates:
+                if (
+                    not source.url
+                    or source.url in seen
+                ):
+                    continue
+
+                seen.add(source.url)
+                sources.append(source)
+                added = True
+
+                if (
+                    len(sources)
+                    >= self.policy.max_results
+                ):
+                    break
+
+            if added:
+                providers.append(provider)
+
+        add(
+            "official_catalog",
+            self._official_sources(clean),
+        )
+
+        provider_calls = (
+            (
+                "duckduckgo_html",
+                self._duckduckgo,
+            ),
+            (
+                "duckduckgo_lite",
+                self._duckduckgo_lite,
+            ),
+            (
+                "wikipedia_opensearch",
+                self._wikipedia,
+            ),
+            (
+                "github_repository_search",
+                self._github,
+            ),
+            (
+                "arxiv",
+                self._arxiv,
+            ),
+        )
+
+        for provider_name, provider_call in provider_calls:
+            if (
+                len(sources)
+                >= self.policy.max_results
+            ):
+                break
+
             try:
-                sources = self._wikipedia(clean)
+                candidates = provider_call(clean)
             except (
                 ResearchError,
                 requests.RequestException,
                 ValueError,
                 json.JSONDecodeError,
-            ) as exc:
-                raise ResearchError(f"No public results available: {exc}") from exc
+                ET.ParseError,
+            ):
+                candidates = []
+
+            add(
+                provider_name,
+                candidates,
+            )
+
+        if not sources:
+            raise ResearchError(
+                "No public results available from "
+                "official documentation, DuckDuckGo, "
+                "Wikipedia, GitHub, or arXiv"
+            )
+
         enriched = tuple(
-            self._excerpt(source) if index < self.policy.max_pages else source
-            for index, source in enumerate(sources)
+            self._excerpt(source)
+            if index < self.policy.max_pages
+            else source
+            for index, source in enumerate(
+                sources
+            )
         )
-        return ResearchReport(clean, enriched, provider)
+
+        return ResearchReport(
+            clean,
+            enriched,
+            "+".join(providers)
+            or "multi_source_public_research",
+        )

--- a/src/garvis/research_governance.py
+++ b/src/garvis/research_governance.py
@@ -1,0 +1,414 @@
+"""Hypercube Heartbeat governance for interactive GARVIS internet research.
+
+Project and conceptual architecture: Adrien D. Thomas (ProCityHub/GARVIS).
+
+GARVIS may research and propose freely. The language model does not certify
+its own output: evidence is hash-bound, the cognitive snapshot is validated,
+and explicit numerical claims are recalculated independently.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from .hypercube_snapshot import validate_hypercube_snapshot
+from .internet_research import ResearchReport
+from .research_hypercube_bridge import BridgeError, verify_math_claims
+from .stage_gate import new_identifier
+from .upgrade_research import (
+    EvidenceLedger,
+    SourceTier,
+    evidence_from_source,
+    record_all,
+    sufficient_for_patch,
+)
+
+MATH_MARKER = "GARVIS_MATH_CLAIMS_JSON="
+
+_MATH_REQUEST = re.compile(
+    r"\b(?:math|mathematics|equation|formula|proof|prove|calculate|"
+    r"calculation|frequency|frequencies|hypercube|lattice)\b",
+    re.IGNORECASE,
+)
+
+
+def research_verification_contract(request: str) -> str:
+    return (
+        request.rstrip()
+        + "\n\nHYPERCUBE HEARTBEAT VERIFICATION CONTRACT: "
+        + "Separate observation, evidence, hypothesis, assumption, inference, "
+        + "and conclusion. Do not describe consciousness, AGI, quantum, lattice, "
+        + "frequency, or other theoretical claims as proven unless retrieved "
+        + "evidence actually establishes them. At the end emit exactly one line "
+        + "beginning "
+        + MATH_MARKER
+        + " followed by a JSON array. Each explicit numerical claim must contain "
+        + "claim_id, expression, expected, tolerance, and meaning. Expressions "
+        + "may contain numeric constants, parentheses, +, -, *, /, %, and integer "
+        + "powers only. Emit [] when no machine-checkable numerical claim exists."
+    )
+
+
+def _extract_math_claims(
+    answer: str,
+) -> Tuple[str, List[Dict[str, Any]], Optional[str]]:
+    clean_lines: List[str] = []
+    claims: Optional[List[Dict[str, Any]]] = None
+    error: Optional[str] = None
+
+    for line in answer.splitlines():
+        stripped = line.strip()
+
+        if not stripped.startswith(MATH_MARKER):
+            clean_lines.append(line)
+            continue
+
+        if claims is not None:
+            error = "multiple math-claim records were emitted"
+            continue
+
+        raw = stripped[len(MATH_MARKER):].strip()
+
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            claims = []
+            error = "math-claim JSON was malformed: %s" % exc
+            continue
+
+        if not isinstance(payload, list):
+            claims = []
+            error = "math-claim record must be a JSON array"
+            continue
+
+        normalized: List[Dict[str, Any]] = []
+
+        for item in payload:
+            if not isinstance(item, dict):
+                normalized = []
+                error = "every math claim must be a JSON object"
+                break
+            normalized.append(dict(item))
+
+        claims = normalized
+
+    return "\n".join(clean_lines).strip(), claims or [], error
+
+
+def _math_requested(request: str) -> bool:
+    return bool(_MATH_REQUEST.search(request))
+
+
+def govern_research_answer(
+    request: str,
+    answer: str,
+    report: ResearchReport,
+    repository_root: Path,
+    *,
+    session_id: str,
+    garvis_home: Optional[Path] = None,
+) -> Tuple[str, Dict[str, Any]]:
+
+    clean_answer, claims, marker_error = _extract_math_claims(answer)
+
+    home = garvis_home or Path(
+        os.getenv(
+            "GARVIS_HOME",
+            str(Path.home() / ".garvis"),
+        )
+    ).expanduser()
+
+    ledger = EvidenceLedger(
+        home / "evidence" / "interactive_research.json"
+    )
+
+    records = []
+    previous_hash = ledger.head_hash()
+
+    for source in report.sources:
+        material = source.excerpt or source.snippet or source.title
+
+        record = evidence_from_source(
+            query=report.query,
+            url=source.url,
+            content=material.encode("utf-8", errors="replace"),
+            claim=source.snippet or source.title,
+            confidence="medium",
+            affects="interactive GARVIS research",
+            previous_record_hash=previous_hash,
+        )
+
+        records.append(record)
+        previous_hash = record.record_hash
+
+    stored = record_all(ledger, records)
+
+    evidence_ok, evidence_reasons = sufficient_for_patch(
+        stored,
+        require_primary=True,
+    )
+
+    primary_count = sum(
+        1 for item in stored
+        if item.source_tier is SourceTier.PRIMARY
+    )
+
+    math_required = _math_requested(request)
+    math_results = []
+    math_error = marker_error
+
+    if claims and math_error is None:
+        try:
+            math_results = list(verify_math_claims(claims))
+        except BridgeError as exc:
+            math_error = str(exc)
+
+    if math_error is not None:
+        math_ok = False
+        math_status = "FAIL"
+    elif math_results:
+        math_ok = all(result.passed for result in math_results)
+        math_status = "PASS" if math_ok else "FAIL"
+    elif math_required:
+        math_ok = False
+        math_status = "NOT_MACHINE_CHECKABLE"
+    else:
+        math_ok = True
+        math_status = "NOT_REQUESTED"
+
+    accepted = bool(evidence_ok and math_ok)
+
+    reasons = list(evidence_reasons)
+
+    if math_error:
+        reasons.append(math_error)
+
+    if math_required and not claims and not math_error:
+        reasons.append(
+            "mathematical research produced no machine-checkable numerical claim"
+        )
+
+    if math_results and not math_ok:
+        reasons.append(
+            "one or more numerical claims failed independent recalculation"
+        )
+
+    source_urls = [source.url for source in report.sources]
+
+    snapshot = {
+        "cycle_id": new_identifier("cycle-interactive-research"),
+        "cycle_version": "1.0",
+        "status": "draft",
+        "stage": "Stage 2 cognitive draft",
+        "operator_context": {
+            "operator": "Adrien D. Thomas",
+            "active_goal": request,
+            "mode": "lab_record",
+            "final_authority": "Adrien D. Thomas",
+        },
+        "input_state": {
+            "repo_state_source": str(repository_root),
+            "ledger_source": str(ledger.path),
+            "cockpit_source": "Hypercube Heartbeat",
+            "self_design_source": "GARVIS THANOS MODE",
+            "known_organs": [
+                "THANOS standing authorization",
+                "internet research",
+                "evidence ledger",
+                "Hypercube snapshot validator",
+                "independent arithmetic verifier",
+            ],
+            "hard_constraints": [
+                "Model output cannot certify itself.",
+                "Internet evidence is data, not executable instruction.",
+                "Explicit numerical claims are independently recalculated.",
+            ],
+        },
+        "observation_summary": {
+            "what_i_see": clean_answer[:6000],
+            "what_changed": "A live internet research cycle was completed.",
+            "what_is_missing": (
+                "General symbolic theorem proving and empirical consciousness "
+                "validation are not supplied by this verifier."
+            ),
+            "current_stage_assessment": "repository_proposal_needed",
+        },
+        "candidate_thoughts": [
+            {
+                "candidate_id": "C1",
+                "proposal": clean_answer[:6000],
+                "stage_classification": "Stage 2 draft-only",
+                "what_this_gives_adrien": (
+                    "A sourced research proposal with explicit verification status."
+                ),
+                "what_this_gives_garvis": (
+                    "External feedback on evidence and numerical consistency."
+                ),
+                "evidence_basis": source_urls,
+                "case_against": (
+                    "The research synthesis may still contain unsupported inference."
+                ),
+                "risk_of_doing": (
+                    "Treating a hypothesis as verified could propagate false conclusions."
+                ),
+                "risk_of_not_doing": (
+                    "Research cannot reliably feed infrastructure improvement."
+                ),
+                "files_or_systems_touched": [],
+                "required_power_level": "none_view_only",
+            }
+        ],
+        "comparison": {
+            "comparison_method": (
+                "Compare evidence strength, counterarguments, uncertainty, "
+                "and independent numerical checks."
+            ),
+            "dominant_tradeoff": (
+                "Research breadth versus falsifiability and reproducibility."
+            ),
+            "why_not_all_candidates": (
+                "Only the current candidate was generated in this cycle."
+            ),
+            "anti_rationalization_check": (
+                "A GARVIS-generated conclusion is not its own proof."
+            ),
+        },
+        "selection": {
+            "selected_candidate_id": "C1",
+            "decision": "recommend" if accepted else "reject",
+            "reasoning": (
+                "Evidence and required numerical verification passed."
+                if accepted
+                else
+                "The candidate did not satisfy the complete Hypercube verification gate."
+            ),
+            "confidence": "medium" if accepted else "low",
+            "blocked": not accepted,
+            "block_reason": None if accepted else "; ".join(reasons),
+        },
+        "uncertainty": {
+            "unknowns": [
+                "Unstructured symbolic equations are not proved by the arithmetic verifier.",
+                "Consciousness and AGI claims require evidence beyond structural validation.",
+            ],
+            "assumptions": [
+                "Retrieved excerpts accurately represent the retrieved material.",
+            ],
+            "what_would_change_my_mind": [
+                "Contradictory primary evidence.",
+                "A failed independent calculation.",
+                "A reproducible competing model with stronger predictive performance.",
+            ],
+            "required_human_clarification": [],
+        },
+        "power_request": {
+            "power_requested": False,
+            "requested_stage": "none",
+            "requested_permissions": [],
+            "why_power_is_needed": "",
+            "why_power_should_be_refused": (
+                "This cycle performs research and verification only."
+            ),
+            "approval_required": False,
+            "ledger_required": True,
+        },
+        "next_smallest_step": {
+            "step": (
+                "Use accepted evidence to form a testable proposal; return failed "
+                "verification to GARVIS for another research cycle."
+            ),
+            "stage": "Stage 2 draft-only",
+            "expected_output": "A falsifiable proposal or a documented rejection.",
+            "success_condition": (
+                "Evidence and required numerical verification pass."
+            ),
+            "stop_condition": (
+                "Do not treat failed or unverified claims as established."
+            ),
+        },
+        "evolution_contract": {
+            "may_self_observe": True,
+            "may_self_propose": True,
+            "may_self_criticize": True,
+            "may_request_more_power": True,
+            "may_self_execute": False,
+            "power_unlock_requires_approval_ledger": True,
+        },
+        "output_boundary": {
+            "can_execute_actions": False,
+            "can_modify_files": False,
+            "can_commit": False,
+            "can_push": False,
+            "can_contact_outside_world": False,
+            "can_upgrade_claims": False,
+            "output_is_advisory": True,
+        },
+    }
+
+    validated = validate_hypercube_snapshot(snapshot)
+
+    result: Dict[str, Any] = {
+        "owner": "Adrien D. Thomas",
+        "session_id": session_id,
+        "query": request,
+        "research_provider": report.provider,
+        "source_count": len(report.sources),
+        "primary_source_count": primary_count,
+        "evidence_gate_passed": evidence_ok,
+        "evidence_gate_reasons": list(evidence_reasons),
+        "snapshot_validation": "PASS",
+        "snapshot": validated,
+        "math_required": math_required,
+        "math_verification": [
+            item.to_payload() for item in math_results
+        ],
+        "math_verification_status": math_status,
+        "math_error": math_error,
+        "hypercube_acceptance": "PASS" if accepted else "FAIL",
+        "model_output_is_self_certifying": False,
+    }
+
+    output = (
+        home
+        / "hypercube"
+        / "latest_interactive_research.json"
+    )
+
+    output.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    output.write_text(
+        json.dumps(result, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    result["verification_record"] = str(output)
+
+    return clean_answer, result
+
+
+def render_governance_status(result: Dict[str, Any]) -> str:
+    return "\n".join(
+        (
+            "HYPERCUBE_HEARTBEAT",
+            "SNAPSHOT_VALIDATION=%s" % result["snapshot_validation"],
+            "EVIDENCE_GATE=%s"
+            % ("PASS" if result["evidence_gate_passed"] else "FAIL"),
+            "MATH_VERIFICATION=%s"
+            % result["math_verification_status"],
+            "HYPERCUBE_ACCEPTANCE=%s"
+            % result["hypercube_acceptance"],
+            "SOURCE_COUNT=%s"
+            % result["source_count"],
+            "PRIMARY_SOURCE_COUNT=%s"
+            % result["primary_source_count"],
+            "VERIFICATION_RECORD=%s"
+            % result["verification_record"],
+        )
+    )

--- a/tests/garvis/test_internet_research.py
+++ b/tests/garvis/test_internet_research.py
@@ -15,3 +15,71 @@ from garvis.internet_research import ResearchError, _validate_public_url
 def test_blocked_urls(url: str) -> None:
     with pytest.raises(ResearchError):
         _validate_public_url(url)
+
+
+def test_official_asyncio_source_is_query_driven(monkeypatch) -> None:
+    from garvis.internet_research import InternetResearchClient, ResearchPolicy
+
+    client = InternetResearchClient(
+        policy=ResearchPolicy(
+            max_results=1,
+            max_pages=0,
+        )
+    )
+
+    report = client.research(
+        "Research the current official Python asyncio documentation"
+    )
+
+    assert len(report.sources) == 1
+    assert (
+        report.sources[0].url
+        == "https://docs.python.org/3/library/asyncio.html"
+    )
+    assert report.sources[0].domain == "docs.python.org"
+    assert "official_catalog" in report.provider
+
+
+def test_zero_source_report_is_refused(monkeypatch) -> None:
+    from garvis.internet_research import InternetResearchClient
+
+    client = InternetResearchClient()
+
+    monkeypatch.setattr(
+        client,
+        "_official_sources",
+        lambda _query: [],
+    )
+    monkeypatch.setattr(
+        client,
+        "_duckduckgo",
+        lambda _query: [],
+    )
+    monkeypatch.setattr(
+        client,
+        "_duckduckgo_lite",
+        lambda _query: [],
+    )
+    monkeypatch.setattr(
+        client,
+        "_wikipedia",
+        lambda _query: [],
+    )
+    monkeypatch.setattr(
+        client,
+        "_github",
+        lambda _query: [],
+    )
+    monkeypatch.setattr(
+        client,
+        "_arxiv",
+        lambda _query: [],
+    )
+
+    with pytest.raises(
+        ResearchError,
+        match="No public results available",
+    ):
+        client.research(
+            "a query with no available source"
+        )

--- a/tests/garvis/test_thanos_research_runtime.py
+++ b/tests/garvis/test_thanos_research_runtime.py
@@ -19,7 +19,7 @@ class FakeLocal:
     def __init__(self, repository_root: Path, answer: str) -> None:
         self.repository_root = repository_root
         self.answer = answer
-        self.calls = []
+        self.calls: list[tuple[str, str, str]] = []
 
     def respond(
         self,
@@ -36,7 +36,7 @@ class FakeLocal:
 
 class PrimaryResearcher:
     def __init__(self) -> None:
-        self.queries = []
+        self.queries: list[str] = []
 
     def research(self, query: str) -> ResearchReport:
         self.queries.append(query)

--- a/tests/garvis/test_thanos_research_runtime.py
+++ b/tests/garvis/test_thanos_research_runtime.py
@@ -1,0 +1,231 @@
+from pathlib import Path
+
+from garvis.capability_broker import ApprovalStore
+from garvis.capability_runtime import (
+    CapabilityAwareRuntime,
+    CapabilityRuntimeConfig,
+)
+from garvis.internet_research import ResearchReport, ResearchSource
+from garvis.local_file_access import LocalFileAccessStore
+from garvis.research_governance import govern_research_answer
+from garvis.thanos_mode import (
+    ThanosAuthorizationStore,
+    create_authorization,
+    revoke_authorization,
+)
+
+
+class FakeLocal:
+    def __init__(self, repository_root: Path, answer: str) -> None:
+        self.repository_root = repository_root
+        self.answer = answer
+        self.calls = []
+
+    def respond(
+        self,
+        message: str,
+        *,
+        external_context: str = "",
+        workspace_context: str = "",
+    ) -> str:
+        self.calls.append(
+            (message, external_context, workspace_context)
+        )
+        return self.answer
+
+
+class PrimaryResearcher:
+    def __init__(self) -> None:
+        self.queries = []
+
+    def research(self, query: str) -> ResearchReport:
+        self.queries.append(query)
+
+        return ResearchReport(
+            query,
+            (
+                ResearchSource(
+                    "Python documentation",
+                    "https://docs.python.org/3/",
+                    "docs.python.org",
+                    "Official Python documentation.",
+                    "Official Python language and library documentation.",
+                ),
+            ),
+            "test-primary",
+        )
+
+
+def build_runtime(
+    tmp_path: Path,
+    *,
+    store: ThanosAuthorizationStore,
+    answer: str,
+):
+    local = FakeLocal(tmp_path, answer)
+    researcher = PrimaryResearcher()
+
+    runtime = CapabilityAwareRuntime(
+        local,
+        approval_store=ApprovalStore(
+            tmp_path / "broker.db"
+        ),
+        local_access_store=LocalFileAccessStore(
+            tmp_path / "local.db"
+        ),
+        researcher=researcher,
+        config=CapabilityRuntimeConfig("thanos"),
+        thanos_store=store,
+    )
+
+    return runtime, local, researcher
+
+
+def test_runtime_config_preserves_approval_default(monkeypatch) -> None:
+    monkeypatch.delenv(
+        "GARVIS_NETWORK_MODE",
+        raising=False,
+    )
+
+    assert (
+        CapabilityRuntimeConfig
+        .from_environment()
+        .network_mode
+        == "approval"
+    )
+
+
+def test_runtime_config_accepts_thanos(monkeypatch) -> None:
+    monkeypatch.setenv(
+        "GARVIS_NETWORK_MODE",
+        "thanos",
+    )
+
+    assert (
+        CapabilityRuntimeConfig
+        .from_environment()
+        .network_mode
+        == "thanos"
+    )
+
+
+def test_active_thanos_researches_without_prompt(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv(
+        "GARVIS_HOME",
+        str(tmp_path / "garvis-home"),
+    )
+
+    store = ThanosAuthorizationStore(
+        tmp_path / "thanos.json"
+    )
+
+    store.append(create_authorization())
+
+    runtime, local, researcher = build_runtime(
+        tmp_path,
+        store=store,
+        answer=(
+            "Research answer [S1]\n"
+            "GARVIS_MATH_CLAIMS_JSON=[]"
+        ),
+    )
+
+    result = runtime.respond(
+        "Research current Python documentation"
+    )
+
+    assert "Approve? [Y/N]" not in result
+    assert researcher.queries == [
+        "Research current Python documentation"
+    ]
+    assert local.calls
+    assert "HYPERCUBE_HEARTBEAT" in result
+    assert "SNAPSHOT_VALIDATION=PASS" in result
+    assert "EVIDENCE_GATE=PASS" in result
+    assert "HYPERCUBE_ACCEPTANCE=PASS" in result
+
+    runtime.close()
+
+
+def test_revoked_thanos_cannot_research(
+    tmp_path: Path,
+) -> None:
+    store = ThanosAuthorizationStore(
+        tmp_path / "thanos.json"
+    )
+
+    active = store.append(
+        create_authorization()
+    )
+
+    store.append(
+        revoke_authorization(
+            active,
+            reason="test revocation",
+        )
+    )
+
+    runtime, local, researcher = build_runtime(
+        tmp_path,
+        store=store,
+        answer="should not run",
+    )
+
+    result = runtime.respond(
+        "Research current Python documentation"
+    )
+
+    assert (
+        "standing internet research unavailable"
+        in result
+    )
+    assert researcher.queries == []
+    assert local.calls == []
+
+    runtime.close()
+
+
+def test_hypercube_recalculates_numeric_claim(
+    tmp_path: Path,
+) -> None:
+    report = ResearchReport(
+        "research math",
+        (
+            ResearchSource(
+                "Python documentation",
+                "https://docs.python.org/3/",
+                "docs.python.org",
+                "Official documentation.",
+                "Official documentation.",
+            ),
+        ),
+        "test-primary",
+    )
+
+    answer = (
+        "Candidate numerical test [S1]\n"
+        'GARVIS_MATH_CLAIMS_JSON=['
+        '{"claim_id":"M1",'
+        '"expression":"(6 / 10) + (4 / 10)",'
+        '"expected":"1",'
+        '"tolerance":"1e-12",'
+        '"meaning":"normalization test"}]'
+    )
+
+    clean, result = govern_research_answer(
+        "research mathematics for a hypercube model",
+        answer,
+        report,
+        tmp_path,
+        session_id="test",
+        garvis_home=tmp_path / "garvis-home",
+    )
+
+    assert "GARVIS_MATH_CLAIMS_JSON" not in clean
+    assert result["snapshot_validation"] == "PASS"
+    assert result["math_verification_status"] == "PASS"
+    assert result["hypercube_acceptance"] == "PASS"
+    assert result["math_verification"][0]["actual"] == "1"


### PR DESCRIPTION
Owner and final authority: Adrien D. Thomas

Connects normal GARVIS to standing THANOS internet research, multi-source discovery, evidence recording, Hypercube snapshot validation, and independent numerical verification.

Local verification: 500 GARVIS tests + 3 subtests passed; guard PASS; security review PASS; live evidence gate PASS; live Hypercube acceptance PASS.

Adrien-Approval: APPROVE PR STAGE

This PR does not authorize merge or deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a standing-authority mode for internet research, allowing authorized research without repeated prompts.
  - Added governance status reporting for evidence quality, mathematical verification, and acceptance outcomes.
  - Expanded research coverage across official sources, DuckDuckGo, Wikipedia, GitHub, and arXiv.
  - Improved result validation, source deduplication, and provider fallback behavior.

- **Bug Fixes**
  - Research now reports a clear error after all available sources return no results.
  - Revoked standing authority prevents further internet research.

- **Tests**
  - Added coverage for authorization, provider selection, fallback behavior, and verification results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->