### PR TITLE
fix(research): harden PR 75 research governance

### DIFF
--- a/src/garvis/internet_research.py
+++ b/src/garvis/internet_research.py
@@ -323,7 +323,8 @@ class InternetResearchClient:
         )
 
         links = re.findall(
-            r'<a[^>]+href=["\']([^"\']+)["\'][^>]*>(.*?)</a>',
+            r'<a(?=[^>]*\bclass=["\'][^"\']*result-link[^"\']*["\'])'
+            r'[^>]+href=["\']([^"\']+)["\'][^>]*>(.*?)</a>',
             text,
             re.I | re.S,
         )
@@ -401,6 +402,9 @@ class InternetResearchClient:
                 errors="replace",
             )
         )
+
+        if not isinstance(data, dict):
+            return []
 
         items = data.get("items", [])
 

--- a/src/garvis/research_governance.py
+++ b/src/garvis/research_governance.py
@@ -381,14 +381,23 @@ def govern_research_answer(
     output.parent.mkdir(
         parents=True,
         exist_ok=True,
+        mode=0o700,
     )
+    output.parent.chmod(0o700)
+
+    result["verification_record"] = str(output)
+
+    output.touch(
+        mode=0o600,
+        exist_ok=True,
+    )
+    output.chmod(0o600)
 
     output.write_text(
         json.dumps(result, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
     )
-
-    result["verification_record"] = str(output)
+    output.chmod(0o600)
 
     return clean_answer, result
 

--- a/tests/garvis/test_cli.py
+++ b/tests/garvis/test_cli.py
@@ -138,3 +138,59 @@ def test_build_local_runtime_normalizes_shared_session_id(
         "local": expected_session_id,
         "capability": expected_session_id,
     }
+
+
+
+def test_build_local_runtime_intentionally_defaults_cli_to_thanos(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, str | None] = {}
+
+    monkeypatch.delenv(
+        "GARVIS_NETWORK_MODE",
+        raising=False,
+    )
+
+    class FakeLocalRuntimeConfig:
+        @staticmethod
+        def from_environment(_repository_root: object) -> object:
+            return object()
+
+    class FakeLocalLanguageRuntime:
+        def __init__(
+            self,
+            _config: object,
+            *,
+            session_id: str,
+        ) -> None:
+            captured["session_id"] = session_id
+
+    class FakeCapabilityAwareRuntime:
+        def __init__(
+            self,
+            _local_runtime: object,
+            *,
+            session_id: str,
+        ) -> None:
+            captured["network_mode_during_construction"] = (
+                cli.os.environ.get("GARVIS_NETWORK_MODE")
+            )
+            captured["capability_session_id"] = session_id
+
+    monkeypatch.setattr(
+        "garvis.local_language_runtime.LocalRuntimeConfig",
+        FakeLocalRuntimeConfig,
+    )
+    monkeypatch.setattr(
+        "garvis.local_language_runtime.LocalLanguageRuntime",
+        FakeLocalLanguageRuntime,
+    )
+    monkeypatch.setattr(
+        "garvis.capability_runtime.CapabilityAwareRuntime",
+        FakeCapabilityAwareRuntime,
+    )
+
+    cli._build_local_runtime()
+
+    assert captured["network_mode_during_construction"] == "thanos"
+    assert "GARVIS_NETWORK_MODE" not in cli.os.environ

--- a/tests/garvis/test_cli.py
+++ b/tests/garvis/test_cli.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import os
 
 import asyncio
 
@@ -173,7 +174,7 @@ def test_build_local_runtime_intentionally_defaults_cli_to_thanos(
             session_id: str,
         ) -> None:
             captured["network_mode_during_construction"] = (
-                cli.os.environ.get("GARVIS_NETWORK_MODE")
+                os.environ.get("GARVIS_NETWORK_MODE")
             )
             captured["capability_session_id"] = session_id
 
@@ -193,4 +194,4 @@ def test_build_local_runtime_intentionally_defaults_cli_to_thanos(
     cli._build_local_runtime()
 
     assert captured["network_mode_during_construction"] == "thanos"
-    assert "GARVIS_NETWORK_MODE" not in cli.os.environ
+    assert "GARVIS_NETWORK_MODE" not in os.environ

--- a/tests/garvis/test_cli.py
+++ b/tests/garvis/test_cli.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
-import os
 
 import asyncio
+import os
 
 import pytest
 

--- a/tests/garvis/test_internet_research.py
+++ b/tests/garvis/test_internet_research.py
@@ -83,3 +83,70 @@ def test_zero_source_report_is_refused(monkeypatch) -> None:
         client.research(
             "a query with no available source"
         )
+
+
+
+def test_duckduckgo_lite_ignores_non_result_links(monkeypatch) -> None:
+    import garvis.internet_research as research_module
+    from garvis.internet_research import InternetResearchClient, ResearchPolicy
+
+    client = InternetResearchClient(
+        policy=ResearchPolicy(
+            max_results=5,
+            max_pages=0,
+        )
+    )
+
+    html = """
+    <html>
+      <body>
+        <a href="https://navigation.example/help">Navigation</a>
+        <a class="result-link" href="https://result-one.example/page">
+          Result One
+        </a>
+        <a href="https://result-two.example/page" class="result-link">
+          Result Two
+        </a>
+      </body>
+    </html>
+    """
+
+    monkeypatch.setattr(
+        research_module,
+        "_validate_public_url",
+        lambda _url: None,
+    )
+    monkeypatch.setattr(
+        client,
+        "_get",
+        lambda url: (
+            html.encode("utf-8"),
+            "text/html",
+            url,
+        ),
+    )
+
+    results = client._duckduckgo_lite("test query")
+
+    assert [item.url for item in results] == [
+        "https://result-one.example/page",
+        "https://result-two.example/page",
+    ]
+
+
+def test_github_non_object_payload_returns_empty(monkeypatch) -> None:
+    from garvis.internet_research import InternetResearchClient
+
+    client = InternetResearchClient()
+
+    monkeypatch.setattr(
+        client,
+        "_get",
+        lambda url: (
+            b'["unexpected", "payload"]',
+            "application/json",
+            url,
+        ),
+    )
+
+    assert client._github("python autonomous agent") == []

--- a/tests/garvis/test_thanos_research_runtime.py
+++ b/tests/garvis/test_thanos_research_runtime.py
@@ -229,3 +229,42 @@ def test_hypercube_recalculates_numeric_claim(
     assert result["math_verification_status"] == "PASS"
     assert result["hypercube_acceptance"] == "PASS"
     assert result["math_verification"][0]["actual"] == "1"
+
+
+
+def test_governance_record_is_private_and_self_describing(
+    tmp_path: Path,
+) -> None:
+    import json
+
+    report = ResearchReport(
+        "research current Python documentation",
+        (
+            ResearchSource(
+                "Python documentation",
+                "https://docs.python.org/3/",
+                "docs.python.org",
+                "Official Python documentation.",
+                "Official Python documentation.",
+            ),
+        ),
+        "test-primary",
+    )
+
+    _, result = govern_research_answer(
+        "research current Python documentation",
+        "Evidence [S1]\nGARVIS_MATH_CLAIMS_JSON=[]",
+        report,
+        tmp_path,
+        session_id="permissions-test",
+        garvis_home=tmp_path / "garvis-home",
+    )
+
+    record = Path(result["verification_record"])
+    persisted = json.loads(
+        record.read_text(encoding="utf-8")
+    )
+
+    assert persisted["verification_record"] == str(record)
+    assert record.stat().st_mode & 0o777 == 0o600
+    assert record.parent.stat().st_mode & 0o777 == 0o700


### PR DESCRIPTION
## Owner

Adrien D. Thomas

## Purpose

Follow-up hardening for PR #75 based on validated review findings.

## Repairs

- Restrict DuckDuckGo Lite parsing to actual result links.
- Reject malformed/non-object GitHub search JSON safely.
- Restrict Hypercube verification directory to 0700.
- Restrict verification records to 0600.
- Persist verification_record inside the JSON record.
- Explicitly test the intentional CLI default to THANOS standing research.
- Add regression tests covering these behaviors.

## Verification

- 21 targeted tests passed
- 510 GARVIS tests + 3 subtests passed
- repository guard passed
- secret scan passed
- dangerous execution scan passed
- network safety scan passed
- permission logic verified
- Python compilation passed

## Approval

Owner: Adrien D. Thomas
Adrien-Approval: APPROVE FOLLOWUP PR STAGE

## Boundary

This approval authorizes commit, push, and pull-request creation only.

It does not authorize merge or deployment.

Commit: dc10d949d40c0ee644aa1294d7da5fd55d9123a6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved internet research results by excluding unrelated DuckDuckGo links.
  - Added safer handling for unexpected GitHub search responses, avoiding errors and returning no results when needed.
  - Verification records are now stored with restricted access permissions and include their own file location.
  - Local runtime setup now consistently defaults to the secure “thanos” network mode when no mode is configured.

- **Tests**
  - Expanded coverage for research filtering, malformed responses, secure record storage, and runtime defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->