### PR TITLE
feat(garvis): add Universal AI Router V1.1

### DIFF
--- a/docs/research/UNIVERSAL_AI_ROUTER_V1_1.md
+++ b/docs/research/UNIVERSAL_AI_ROUTER_V1_1.md
@@ -1,0 +1,68 @@
+# GARVIS Universal AI Router V1.1
+
+Creator / conceptual architect: **Adrien D. Thomas**
+
+## Purpose
+
+GARVIS remains the orchestrator. External AI systems are replaceable candidate
+reasoning organs, not identities, truth authorities, or execution authorities.
+
+V1.1 provides:
+
+- normalized provider identity metadata,
+- explicit provider capability metadata,
+- deterministic health-aware candidate ordering,
+- Hypercube perspective scheduling,
+- fail-closed handling of unknown provider identities,
+- explicit distinction between installed AI apps and programmable adapters.
+
+## Hypercube ownership boundary
+
+The initial scheduling invariant preserves:
+
+- `001 Context` -> GARVIS,
+- `100 Evidence` -> GARVIS evidence,
+- `111 Integration` -> GARVIS.
+
+External provider output remains `CANDIDATE_ONLY`.
+
+## Provider identity security
+
+Known provider families are resolved explicitly. Unknown provider/model
+identifiers fail closed with no supported adapter and are not programmable.
+
+Environment-variable presence is availability metadata only. It does not
+establish identity, capability, evidence, trust, or authority.
+
+## Health boundary
+
+Provider health is operational routing evidence only. Recorded success,
+failure count, or block status must never be interpreted as proof that a
+provider answer is true.
+
+## Security review
+
+The standalone prototype completed:
+
+- prototype validation,
+- adversarial tests,
+- fail-closed identity hardening,
+- security review rerun with 0 CRITICAL and 0 HIGH findings.
+
+The remaining environment-trust note is retained as an architectural boundary:
+environment configuration may signal availability only.
+
+## Scientific / project boundary
+
+This work supports the GARVIS AGI research program. It does not establish AGI,
+consciousness, singularity, or a new physical law.
+
+## Governance
+
+Adrien-Approval: **APPROVE GARVIS UNIVERSAL AI ROUTER V1.1 PR STAGE**
+
+This approval authorizes integration testing, commit, push, and draft pull
+request creation for this artifact only.
+
+Merge, deployment, real provider calls, purchases, messaging, deletion,
+installation, and device-control permissions are not authorized.

--- a/docs/research/UNIVERSAL_AI_ROUTER_V1_1_ARTIFACTS.txt
+++ b/docs/research/UNIVERSAL_AI_ROUTER_V1_1_ARTIFACTS.txt
@@ -1,0 +1,11 @@
+Creator: Adrien D. Thomas
+Approval: APPROVE GARVIS UNIVERSAL AI ROUTER V1.1 PR STAGE
+Base: main
+Base SHA: 107470f1b41d627464b24e2b2d0cf7ed6812e495
+
+Approved standalone source/test hashes:
+c6a827a0b37c74aeb37945435d7c425427b902eaa1d345b378ce9f02de708280  /data/data/com.termux/files/home/garvis-prototypes/universal-ai-router-v1_1-20260727T012726Z/src/garvis/universal_ai_registry.py
+27d03bcdf76b29574cd6cc41f8095d83d2a9655b2c0f1d3315e0a3600e6c22ed  /data/data/com.termux/files/home/garvis-prototypes/universal-ai-router-v1_1-20260727T012726Z/src/garvis/health_aware_router.py
+c9f5c6742db5c24f026595c823b6d1ca11a347e0b197bec67d6d3a26302bcb1e  /data/data/com.termux/files/home/garvis-prototypes/universal-ai-router-v1_1-20260727T012726Z/tests/test_security_hardening.py
+15719dcdc168c40e4c9568a118f5b9ede8d2e50610ad1e80e5e031e48933f43c  /data/data/com.termux/files/home/garvis-prototypes/universal-ai-router-v1_1-20260727T012726Z/tests/test_health_aware_router.py
+4592bbc6e2a3a5309be8b3927a47352ad7510aaeffcb878aec694976cb59aa4d  /data/data/com.termux/files/home/garvis-prototypes/universal-ai-router-v1_1-tests-20260727T020233Z/test_router_adversarial.py

--- a/src/garvis/health_aware_router.py
+++ b/src/garvis/health_aware_router.py
@@ -1,0 +1,104 @@
+"""Health-aware routing metadata for GARVIS Universal AI Router V1.1.
+
+This module never executes a provider. Health is operational routing evidence,
+not evidence that a provider's answer is true.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Mapping, Optional, Tuple
+
+from .universal_ai_registry import AIOrgan, CandidateType, UniversalAIRegistry
+
+
+@dataclass(frozen=True)
+class ProviderHealthSnapshot:
+    model: str
+    failure_count: int = 0
+    last_failure_at: Optional[float] = None
+    last_success_at: Optional[float] = None
+    blocked: bool = False
+
+
+@dataclass(frozen=True)
+class RoutedCandidate:
+    organ_id: str
+    model: Optional[str]
+    provider_id: str
+    blocked: bool
+    failure_count: int
+    has_recorded_success: bool
+    reason: str
+
+
+def _snapshot_for(
+    model: Optional[str],
+    health: Mapping[str, ProviderHealthSnapshot],
+) -> ProviderHealthSnapshot:
+    if not model:
+        return ProviderHealthSnapshot(model="")
+    return health.get(model, ProviderHealthSnapshot(model=model))
+
+
+def rank_remote_candidates(
+    registry: UniversalAIRegistry,
+    health: Mapping[str, ProviderHealthSnapshot],
+    *,
+    capability: str = "text",
+) -> Tuple[RoutedCandidate, ...]:
+    """Rank configured programmable remotes by operational health.
+
+    Ordering:
+    1. not blocked,
+    2. has a recorded success,
+    3. fewer recorded failures,
+    4. stable provider/model lexical tie-break.
+
+    This is intentionally not a truth/intelligence score.
+    """
+    rows = []
+    for organ in registry.candidates(capability):
+        if organ.candidate_type is not CandidateType.REMOTE_API:
+            continue
+        snap = _snapshot_for(organ.model, health)
+        rows.append(
+            (
+                (
+                    1 if snap.blocked else 0,
+                    0 if snap.last_success_at is not None else 1,
+                    max(0, int(snap.failure_count)),
+                    organ.provider_id,
+                    organ.model or "",
+                ),
+                RoutedCandidate(
+                    organ_id=organ.organ_id,
+                    model=organ.model,
+                    provider_id=organ.provider_id,
+                    blocked=snap.blocked,
+                    failure_count=max(0, int(snap.failure_count)),
+                    has_recorded_success=snap.last_success_at is not None,
+                    reason=(
+                        "operational health ordering only; provider output remains "
+                        "candidate information requiring GARVIS verification"
+                    ),
+                ),
+            )
+        )
+    rows.sort(key=lambda row: row[0])
+    return tuple(row[1] for row in rows)
+
+
+def select_unblocked(
+    ranked: Iterable[RoutedCandidate],
+    *,
+    limit: int = 3,
+) -> Tuple[RoutedCandidate, ...]:
+    selected = []
+    for item in ranked:
+        if item.blocked:
+            continue
+        selected.append(item)
+        if len(selected) >= limit:
+            break
+    return tuple(selected)

--- a/src/garvis/health_aware_router.py
+++ b/src/garvis/health_aware_router.py
@@ -94,6 +94,8 @@ def select_unblocked(
     *,
     limit: int = 3,
 ) -> Tuple[RoutedCandidate, ...]:
+    if limit <= 0:
+        return ()
     selected = []
     for item in ranked:
         if item.blocked:

--- a/src/garvis/universal_ai_registry.py
+++ b/src/garvis/universal_ai_registry.py
@@ -1,0 +1,428 @@
+"""GARVIS Universal AI Router V1 prototype.
+
+Creator / conceptual architect: Adrien D. Thomas
+
+This module is intentionally non-executing:
+- it does not call model providers;
+- it does not read secret values into reports;
+- it does not control Android apps;
+- it does not open sockets or start servers.
+
+It inventories candidate AI organs, normalizes provider identity, records
+capability metadata, and produces Hypercube perspective scheduling plans.
+Provider output remains candidate information until GARVIS verification.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Dict, FrozenSet, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+
+class CandidateType(str, Enum):
+    GARVIS_LOCAL = "garvis_local"
+    REMOTE_API = "remote_api"
+    ANDROID_APP = "android_app"
+    LOCAL_RUNTIME = "local_runtime"
+    LOCAL_SERVER = "local_server"
+    GARVIS_ORGAN = "garvis_organ"
+
+
+class AdapterKind(str, Enum):
+    GARVIS_LOCAL = "garvis_local"
+    OPENAI_NATIVE = "openai_native"
+    ANTHROPIC_NATIVE = "anthropic_native"
+    OPENAI_COMPATIBLE = "openai_compatible"
+    MANUAL_ONLY = "manual_only"
+    MISSING = "missing"
+    UNKNOWN = "unknown"
+    INTERNAL = "internal"
+
+
+class Authority(str, Enum):
+    GARVIS = "garvis"
+    CANDIDATE_ONLY = "candidate_only"
+    EVIDENCE_ONLY = "evidence_only"
+
+
+@dataclass(frozen=True)
+class ProviderIdentity:
+    provider_id: str
+    adapter: AdapterKind
+    required_env_names: Tuple[str, ...] = ()
+    required_base_url_env: Optional[str] = None
+    adapter_supported: bool = True
+
+
+@dataclass(frozen=True)
+class AIOrgan:
+    organ_id: str
+    candidate_type: CandidateType
+    provider_id: str
+    model: Optional[str]
+    adapter: AdapterKind
+    configured: bool
+    programmable: bool
+    adapter_supported: bool
+    declared_capabilities: FrozenSet[str] = field(default_factory=frozenset)
+    verified_capabilities: FrozenSet[str] = field(default_factory=frozenset)
+    authority: Authority = Authority.CANDIDATE_ONLY
+    notes: Tuple[str, ...] = ()
+
+    def supports(self, capability: str, *, verified_only: bool = False) -> bool:
+        pool = self.verified_capabilities if verified_only else self.declared_capabilities
+        return capability in pool
+
+
+@dataclass(frozen=True)
+class PerspectiveAssignment:
+    code: str
+    name: str
+    owner: str
+    reason: str
+
+
+PERSPECTIVES: Tuple[Tuple[str, str], ...] = (
+    ("000", "Literal"),
+    ("001", "Context"),
+    ("010", "Intent"),
+    ("011", "Relation"),
+    ("100", "Evidence"),
+    ("101", "Possibility"),
+    ("110", "Consequence"),
+    ("111", "Integration"),
+)
+
+
+def identify_provider(model: str) -> ProviderIdentity:
+    """Resolve a model string using the currently observed GARVIS routing families."""
+    selected = (model or "").strip()
+    lowered = selected.casefold()
+
+    if lowered in {"local", "garvis-local", "garvis/local"}:
+        return ProviderIdentity(
+            provider_id="garvis",
+            adapter=AdapterKind.GARVIS_LOCAL,
+            adapter_supported=True,
+        )
+
+    if lowered.startswith("anthropic/") or lowered.startswith("claude-") or lowered.startswith("claude/"):
+        return ProviderIdentity(
+            provider_id="anthropic",
+            adapter=AdapterKind.ANTHROPIC_NATIVE,
+            required_env_names=("ANTHROPIC_API_KEY",),
+        )
+
+    if lowered.startswith("openrouter/"):
+        return ProviderIdentity(
+            provider_id="openrouter",
+            adapter=AdapterKind.OPENAI_COMPATIBLE,
+            required_env_names=("OPENROUTER_API_KEY",),
+        )
+
+    if lowered.startswith("groq/"):
+        return ProviderIdentity(
+            provider_id="groq",
+            adapter=AdapterKind.OPENAI_COMPATIBLE,
+            required_env_names=("GROQ_API_KEY",),
+        )
+
+    if lowered.startswith("grok/"):
+        return ProviderIdentity(
+            provider_id="xai",
+            adapter=AdapterKind.OPENAI_COMPATIBLE,
+            required_env_names=("XAI_API_KEY",),
+        )
+
+    if lowered.startswith("compatible/"):
+        return ProviderIdentity(
+            provider_id="compatible",
+            adapter=AdapterKind.OPENAI_COMPATIBLE,
+            required_env_names=("GARVIS_COMPAT_API_KEY",),
+            required_base_url_env="GARVIS_COMPAT_BASE_URL",
+        )
+
+    if (
+        lowered.startswith("openai/")
+        or lowered.startswith("gpt-")
+        or lowered == "o1"
+        or lowered.startswith("o1-")
+        or lowered == "o3"
+        or lowered.startswith("o3-")
+        or lowered == "o4"
+        or lowered.startswith("o4-")
+    ):
+        return ProviderIdentity(
+            provider_id="openai",
+            adapter=AdapterKind.OPENAI_NATIVE,
+            required_env_names=("OPENAI_API_KEY",),
+        )
+
+    # Gemini is intentionally discoverable but not treated as already integrated.
+    if lowered.startswith("gemini/"):
+        return ProviderIdentity(
+            provider_id="gemini",
+            adapter=AdapterKind.MISSING,
+            required_env_names=("GEMINI_API_KEY",),
+            adapter_supported=False,
+        )
+
+    # Security-hardening rule: unknown provider identity fails closed.
+    # Environment-variable presence is availability metadata only. It does not
+    # establish provider identity, capability, trust, or execution authority.
+    return ProviderIdentity(
+        provider_id="unknown",
+        adapter=AdapterKind.UNKNOWN,
+        required_env_names=(),
+        adapter_supported=False,
+    )
+
+
+def _present(env: Mapping[str, str], name: str) -> bool:
+    return bool((env.get(name) or "").strip())
+
+
+def configuration_present(identity: ProviderIdentity, env: Mapping[str, str]) -> bool:
+    if any(not _present(env, name) for name in identity.required_env_names):
+        return False
+    if identity.required_base_url_env and not _present(env, identity.required_base_url_env):
+        return False
+    return True
+
+
+def remote_model_organ(
+    model: str,
+    *,
+    env: Mapping[str, str],
+    declared_capabilities: Iterable[str] = ("text",),
+    verified_capabilities: Iterable[str] = (),
+) -> AIOrgan:
+    identity = identify_provider(model)
+    configured = configuration_present(identity, env)
+    notes: List[str] = []
+    if identity.provider_id == "gemini":
+        notes.append("provider discovered; dedicated GARVIS adapter not yet established")
+    if identity.provider_id == "unknown":
+        notes.append("unknown_provider_rejected_fail_closed")
+    if not identity.adapter_supported:
+        notes.append("adapter_missing")
+    if not configured:
+        notes.append("configuration_missing")
+
+    return AIOrgan(
+        organ_id=f"remote:{model}",
+        candidate_type=CandidateType.REMOTE_API,
+        provider_id=identity.provider_id,
+        model=model,
+        adapter=identity.adapter,
+        configured=configured,
+        programmable=bool(identity.adapter_supported and configured),
+        adapter_supported=identity.adapter_supported,
+        declared_capabilities=frozenset(declared_capabilities),
+        verified_capabilities=frozenset(verified_capabilities),
+        authority=Authority.CANDIDATE_ONLY,
+        notes=tuple(notes),
+    )
+
+
+def garvis_local_organ() -> AIOrgan:
+    return AIOrgan(
+        organ_id="garvis:local",
+        candidate_type=CandidateType.GARVIS_LOCAL,
+        provider_id="garvis",
+        model=None,
+        adapter=AdapterKind.GARVIS_LOCAL,
+        configured=True,
+        programmable=True,
+        adapter_supported=True,
+        declared_capabilities=frozenset(
+            {"text", "reasoning", "context", "integration", "planning"}
+        ),
+        verified_capabilities=frozenset(),
+        authority=Authority.GARVIS,
+        notes=("GARVIS-owned local reasoning; capability claims remain testable",),
+    )
+
+
+def garvis_evidence_organ() -> AIOrgan:
+    return AIOrgan(
+        organ_id="garvis:evidence",
+        candidate_type=CandidateType.GARVIS_ORGAN,
+        provider_id="garvis",
+        model=None,
+        adapter=AdapterKind.INTERNAL,
+        configured=True,
+        programmable=True,
+        adapter_supported=True,
+        declared_capabilities=frozenset({"evidence", "research", "verification"}),
+        verified_capabilities=frozenset(),
+        authority=Authority.EVIDENCE_ONLY,
+        notes=("evidence is not model self-certification",),
+    )
+
+
+def android_app_organ(
+    package_name: str,
+    *,
+    label: Optional[str] = None,
+    programmable: bool = False,
+    declared_capabilities: Iterable[str] = (),
+) -> AIOrgan:
+    """Register an installed AI app without pretending GARVIS can control it."""
+    display = label or package_name
+    return AIOrgan(
+        organ_id=f"android:{package_name}",
+        candidate_type=CandidateType.ANDROID_APP,
+        provider_id=display,
+        model=None,
+        adapter=AdapterKind.MANUAL_ONLY if not programmable else AdapterKind.INTERNAL,
+        configured=True,
+        programmable=programmable,
+        adapter_supported=programmable,
+        declared_capabilities=frozenset(declared_capabilities),
+        verified_capabilities=frozenset(),
+        authority=Authority.CANDIDATE_ONLY,
+        notes=(
+            "installed-app presence does not imply a programmable integration",
+        ),
+    )
+
+
+class UniversalAIRegistry:
+    """Pure metadata registry. It never executes providers."""
+
+    def __init__(self, organs: Iterable[AIOrgan] = ()) -> None:
+        self._organs: Dict[str, AIOrgan] = {}
+        for organ in organs:
+            self.register(organ)
+
+    def register(self, organ: AIOrgan) -> None:
+        self._organs[organ.organ_id] = organ
+
+    def all(self) -> Tuple[AIOrgan, ...]:
+        return tuple(self._organs[key] for key in sorted(self._organs))
+
+    def get(self, organ_id: str) -> Optional[AIOrgan]:
+        return self._organs.get(organ_id)
+
+    def candidates(
+        self,
+        capability: str = "text",
+        *,
+        verified_only: bool = False,
+        programmable_only: bool = True,
+    ) -> Tuple[AIOrgan, ...]:
+        found: List[AIOrgan] = []
+        for organ in self.all():
+            if programmable_only and not organ.programmable:
+                continue
+            if not organ.configured or not organ.adapter_supported:
+                continue
+            if organ.supports(capability, verified_only=verified_only):
+                found.append(organ)
+        return tuple(found)
+
+    def safe_report(self) -> Dict[str, object]:
+        """Return metadata only; secret values are never included."""
+        return {
+            "schema": "garvis.universal_ai_registry.v1",
+            "organs": [
+                {
+                    "organ_id": organ.organ_id,
+                    "candidate_type": organ.candidate_type.value,
+                    "provider_id": organ.provider_id,
+                    "model": organ.model,
+                    "adapter": organ.adapter.value,
+                    "configured": organ.configured,
+                    "programmable": organ.programmable,
+                    "adapter_supported": organ.adapter_supported,
+                    "declared_capabilities": sorted(organ.declared_capabilities),
+                    "verified_capabilities": sorted(organ.verified_capabilities),
+                    "authority": organ.authority.value,
+                    "notes": list(organ.notes),
+                }
+                for organ in self.all()
+            ],
+        }
+
+
+def build_registry(
+    models: Sequence[str],
+    *,
+    env: Mapping[str, str],
+    capability_overrides: Optional[Mapping[str, Iterable[str]]] = None,
+    android_packages: Sequence[str] = (),
+) -> UniversalAIRegistry:
+    overrides = capability_overrides or {}
+    registry = UniversalAIRegistry((garvis_local_organ(), garvis_evidence_organ()))
+
+    for model in models:
+        capabilities = overrides.get(model, ("text",))
+        registry.register(
+            remote_model_organ(
+                model,
+                env=env,
+                declared_capabilities=capabilities,
+            )
+        )
+
+    for package_name in android_packages:
+        registry.register(android_app_organ(package_name))
+
+    return registry
+
+
+def hypercube_provider_plan(
+    registry: UniversalAIRegistry,
+    *,
+    capability: str = "text",
+) -> Tuple[PerspectiveAssignment, ...]:
+    """Create a non-executing 8-perspective scheduling plan.
+
+    Context, Evidence, and Integration remain GARVIS-owned. Other perspectives
+    may be rotated across programmable candidate providers. This is a routing
+    plan, not a truth score or provider vote.
+    """
+    remote = [
+        organ
+        for organ in registry.candidates(capability)
+        if organ.candidate_type is CandidateType.REMOTE_API
+    ]
+    local = registry.get("garvis:local")
+    fallback_owner = local.organ_id if local else "garvis:local"
+
+    candidate_codes = {"000", "010", "011", "101", "110"}
+    cursor = 0
+    assignments: List[PerspectiveAssignment] = []
+
+    for code, name in PERSPECTIVES:
+        if code == "001":
+            assignments.append(
+                PerspectiveAssignment(code, name, fallback_owner, "GARVIS context/memory")
+            )
+        elif code == "100":
+            assignments.append(
+                PerspectiveAssignment(code, name, "garvis:evidence", "evidence is independently grounded")
+            )
+        elif code == "111":
+            assignments.append(
+                PerspectiveAssignment(code, name, fallback_owner, "GARVIS integration retains authority")
+            )
+        elif code in candidate_codes and remote:
+            organ = remote[cursor % len(remote)]
+            cursor += 1
+            assignments.append(
+                PerspectiveAssignment(
+                    code,
+                    name,
+                    organ.organ_id,
+                    "candidate perspective; output still requires GARVIS verification",
+                )
+            )
+        else:
+            assignments.append(
+                PerspectiveAssignment(code, name, fallback_owner, "local fallback")
+            )
+
+    return tuple(assignments)

--- a/src/garvis/universal_ai_registry.py
+++ b/src/garvis/universal_ai_registry.py
@@ -274,16 +274,20 @@ def android_app_organ(
     declared_capabilities: Iterable[str] = (),
 ) -> AIOrgan:
     """Register an installed AI app without pretending GARVIS can control it."""
+    if programmable:
+        raise ValueError(
+            "Android app control requires a verified integration adapter"
+        )
     display = label or package_name
     return AIOrgan(
         organ_id=f"android:{package_name}",
         candidate_type=CandidateType.ANDROID_APP,
         provider_id=display,
         model=None,
-        adapter=AdapterKind.MANUAL_ONLY if not programmable else AdapterKind.INTERNAL,
+        adapter=AdapterKind.MANUAL_ONLY,
         configured=True,
-        programmable=programmable,
-        adapter_supported=programmable,
+        programmable=False,
+        adapter_supported=False,
         declared_capabilities=frozenset(declared_capabilities),
         verified_capabilities=frozenset(),
         authority=Authority.CANDIDATE_ONLY,

--- a/src/garvis/universal_ai_registry.py
+++ b/src/garvis/universal_ai_registry.py
@@ -199,7 +199,11 @@ def remote_model_organ(
     verified_capabilities: Iterable[str] = (),
 ) -> AIOrgan:
     identity = identify_provider(model)
-    configured = configuration_present(identity, env)
+    configured = (
+        False
+        if identity.provider_id == "unknown"
+        else configuration_present(identity, env)
+    )
     notes: List[str] = []
     if identity.provider_id == "gemini":
         notes.append("provider discovered; dedicated GARVIS adapter not yet established")

--- a/tests/garvis/test_universal_ai_router_adversarial.py
+++ b/tests/garvis/test_universal_ai_router_adversarial.py
@@ -1,0 +1,232 @@
+import json
+from dataclasses import replace
+
+from garvis.health_aware_router import (
+    ProviderHealthSnapshot,
+    rank_remote_candidates,
+    select_unblocked,
+)
+from garvis.universal_ai_registry import (
+    AdapterKind,
+    Authority,
+    CandidateType,
+    UniversalAIRegistry,
+    android_app_organ,
+    build_registry,
+    garvis_evidence_organ,
+    garvis_local_organ,
+    hypercube_provider_plan,
+    identify_provider,
+    remote_model_organ,
+)
+
+
+def _multi_registry():
+    return build_registry(
+        [
+            "gpt-test",
+            "anthropic/claude-test",
+            "grok/test",
+            "groq/test",
+            "openrouter/test",
+            "compatible/test",
+            "gemini/test",
+        ],
+        env={
+            "OPENAI_API_KEY": "secret-openai",
+            "ANTHROPIC_API_KEY": "secret-anthropic",
+            "XAI_API_KEY": "secret-xai",
+            "GROQ_API_KEY": "secret-groq",
+            "OPENROUTER_API_KEY": "secret-openrouter",
+            "GARVIS_COMPAT_API_KEY": "secret-compat",
+            "GARVIS_COMPAT_BASE_URL": "https://example.invalid",
+            "GEMINI_API_KEY": "secret-gemini",
+        },
+        capability_overrides={
+            "gpt-test": {"text", "reasoning", "coding"},
+            "anthropic/claude-test": {"text", "reasoning", "coding"},
+            "grok/test": {"text", "reasoning", "research"},
+            "groq/test": {"text"},
+            "openrouter/test": {"text"},
+            "compatible/test": {"text"},
+            "gemini/test": {"text", "vision"},
+        },
+    )
+
+
+def test_provider_families_resolve_explicitly():
+    assert identify_provider("gpt-test").provider_id == "openai"
+    assert identify_provider("anthropic/claude-test").provider_id == "anthropic"
+    assert identify_provider("grok/test").provider_id == "xai"
+    assert identify_provider("groq/test").provider_id == "groq"
+    assert identify_provider("openrouter/test").provider_id == "openrouter"
+    assert identify_provider("compatible/test").provider_id == "compatible"
+
+
+def test_gemini_discovery_does_not_fake_adapter():
+    identity = identify_provider("gemini/test")
+    assert identity.provider_id == "gemini"
+    assert identity.adapter is AdapterKind.MISSING
+    assert identity.adapter_supported is False
+
+
+def test_unconfigured_remote_never_becomes_programmable():
+    organ = remote_model_organ("gpt-test", env={})
+    assert organ.configured is False
+    assert organ.programmable is False
+
+
+def test_installed_app_does_not_imply_control():
+    organ = android_app_organ("com.example.ai")
+    assert organ.candidate_type is CandidateType.ANDROID_APP
+    assert organ.programmable is False
+    assert organ.adapter_supported is False
+    assert organ.adapter is AdapterKind.MANUAL_ONLY
+
+
+def test_external_provider_authority_is_candidate_only():
+    registry = _multi_registry()
+    remotes = [o for o in registry.all() if o.candidate_type is CandidateType.REMOTE_API]
+    assert remotes
+    assert all(o.authority is Authority.CANDIDATE_ONLY for o in remotes)
+
+
+def test_garvis_context_evidence_integration_ownership_is_invariant():
+    registry = _multi_registry()
+    plan = {p.code: p for p in hypercube_provider_plan(registry)}
+    assert plan["001"].owner == "garvis:local"
+    assert plan["100"].owner == "garvis:evidence"
+    assert plan["111"].owner == "garvis:local"
+
+
+def test_hypercube_plan_has_exactly_eight_unique_perspectives():
+    registry = _multi_registry()
+    plan = hypercube_provider_plan(registry)
+    assert len(plan) == 8
+    assert {p.code for p in plan} == {
+        "000", "001", "010", "011", "100", "101", "110", "111"
+    }
+
+
+def test_missing_adapter_is_not_routable_even_with_key_present():
+    registry = _multi_registry()
+    text = registry.candidates("text")
+    assert all(item.provider_id != "gemini" for item in text)
+
+
+def test_safe_report_never_contains_supplied_secret_values():
+    registry = _multi_registry()
+    encoded = json.dumps(registry.safe_report(), sort_keys=True)
+    for secret in (
+        "secret-openai",
+        "secret-anthropic",
+        "secret-xai",
+        "secret-groq",
+        "secret-openrouter",
+        "secret-compat",
+        "secret-gemini",
+    ):
+        assert secret not in encoded
+
+
+def test_capability_filter_blocks_wrong_capability():
+    registry = _multi_registry()
+    coding = registry.candidates("coding")
+    assert coding
+    assert {o.provider_id for o in coding} <= {"openai", "anthropic"}
+
+
+def test_health_order_is_not_authority_escalation():
+    registry = _multi_registry()
+    health = {
+        "anthropic/claude-test": ProviderHealthSnapshot(
+            "anthropic/claude-test",
+            last_success_at=100.0,
+        ),
+    }
+    ranked = rank_remote_candidates(registry, health)
+    assert ranked
+    selected_ids = {item.organ_id for item in ranked}
+    organs = {o.organ_id: o for o in registry.all()}
+    assert all(organs[item].authority is Authority.CANDIDATE_ONLY for item in selected_ids)
+
+
+def test_blocked_provider_is_never_selected():
+    registry = _multi_registry()
+    health = {
+        "anthropic/claude-test": ProviderHealthSnapshot(
+            "anthropic/claude-test",
+            blocked=True,
+            last_success_at=100.0,
+        )
+    }
+    selected = select_unblocked(rank_remote_candidates(registry, health), limit=99)
+    assert all(item.model != "anthropic/claude-test" for item in selected)
+
+
+def test_all_blocked_produces_empty_selection():
+    registry = build_registry(
+        ["gpt-test", "anthropic/claude-test"],
+        env={"OPENAI_API_KEY": "x", "ANTHROPIC_API_KEY": "y"},
+    )
+    health = {
+        "gpt-test": ProviderHealthSnapshot("gpt-test", blocked=True),
+        "anthropic/claude-test": ProviderHealthSnapshot(
+            "anthropic/claude-test", blocked=True
+        ),
+    }
+    assert select_unblocked(rank_remote_candidates(registry, health), limit=10) == ()
+
+
+def test_health_ranking_deterministic_under_input_reordering():
+    env = {
+        "OPENAI_API_KEY": "x",
+        "ANTHROPIC_API_KEY": "y",
+        "XAI_API_KEY": "z",
+    }
+    a = build_registry(
+        ["gpt-test", "anthropic/claude-test", "grok/test"], env=env
+    )
+    b = build_registry(
+        ["grok/test", "gpt-test", "anthropic/claude-test"], env=env
+    )
+    health = {
+        "gpt-test": ProviderHealthSnapshot("gpt-test", failure_count=1),
+        "anthropic/claude-test": ProviderHealthSnapshot(
+            "anthropic/claude-test", failure_count=0
+        ),
+        "grok/test": ProviderHealthSnapshot("grok/test", failure_count=2),
+    }
+    assert [x.model for x in rank_remote_candidates(a, health)] == [
+        x.model for x in rank_remote_candidates(b, health)
+    ]
+
+
+def test_false_consensus_cannot_change_registry_authority():
+    registry = _multi_registry()
+    remotes = [
+        replace(o, notes=o.notes + ("three providers agree",))
+        for o in registry.all()
+        if o.candidate_type is CandidateType.REMOTE_API
+    ]
+    assert remotes
+    assert all(o.authority is Authority.CANDIDATE_ONLY for o in remotes)
+
+
+def test_evidence_organ_is_not_provider_candidate():
+    evidence = garvis_evidence_organ()
+    assert evidence.authority is Authority.EVIDENCE_ONLY
+    assert evidence.candidate_type is CandidateType.GARVIS_ORGAN
+
+
+def test_local_garvis_retains_garvis_authority():
+    local = garvis_local_organ()
+    assert local.authority is Authority.GARVIS
+
+
+def test_registry_replacement_by_same_id_is_deterministic():
+    registry = UniversalAIRegistry()
+    a = garvis_local_organ()
+    registry.register(a)
+    registry.register(a)
+    assert len(registry.all()) == 1

--- a/tests/garvis/test_universal_ai_router_health.py
+++ b/tests/garvis/test_universal_ai_router_health.py
@@ -75,3 +75,8 @@ def test_reason_explicitly_preserves_verification_boundary():
     ranked = rank_remote_candidates(registry, {})
     assert ranked
     assert "verification" in ranked[0].reason
+
+def test_select_unblocked_non_positive_limit_returns_empty():
+    ranked = rank_remote_candidates(_registry(), {})
+    assert select_unblocked(ranked, limit=0) == ()
+    assert select_unblocked(ranked, limit=-1) == ()

--- a/tests/garvis/test_universal_ai_router_health.py
+++ b/tests/garvis/test_universal_ai_router_health.py
@@ -1,0 +1,77 @@
+from garvis.health_aware_router import (
+    ProviderHealthSnapshot,
+    rank_remote_candidates,
+    select_unblocked,
+)
+from garvis.universal_ai_registry import build_registry
+
+
+def _registry():
+    return build_registry(
+        ["gpt-test", "anthropic/claude-test", "grok/test"],
+        env={
+            "OPENAI_API_KEY": "present",
+            "ANTHROPIC_API_KEY": "present",
+            "XAI_API_KEY": "present",
+        },
+    )
+
+
+def test_blocked_provider_is_ranked_after_unblocked():
+    registry = _registry()
+    health = {
+        "gpt-test": ProviderHealthSnapshot("gpt-test", blocked=True),
+        "anthropic/claude-test": ProviderHealthSnapshot(
+            "anthropic/claude-test",
+            last_success_at=1.0,
+        ),
+    }
+    ranked = rank_remote_candidates(registry, health)
+    assert ranked[0].model == "anthropic/claude-test"
+    assert ranked[-1].model == "gpt-test"
+
+
+def test_recorded_success_precedes_unproven_when_both_unblocked():
+    registry = _registry()
+    health = {
+        "anthropic/claude-test": ProviderHealthSnapshot(
+            "anthropic/claude-test",
+            last_success_at=1.0,
+        )
+    }
+    ranked = rank_remote_candidates(registry, health)
+    assert ranked[0].model == "anthropic/claude-test"
+
+
+def test_fewer_failures_breaks_unproven_tie():
+    registry = _registry()
+    health = {
+        "gpt-test": ProviderHealthSnapshot("gpt-test", failure_count=2),
+        "anthropic/claude-test": ProviderHealthSnapshot(
+            "anthropic/claude-test",
+            failure_count=1,
+        ),
+        "grok/test": ProviderHealthSnapshot("grok/test", failure_count=0),
+    }
+    ranked = rank_remote_candidates(registry, health)
+    assert [item.model for item in ranked][:3] == [
+        "grok/test",
+        "anthropic/claude-test",
+        "gpt-test",
+    ]
+
+
+def test_select_unblocked_excludes_blocked():
+    registry = _registry()
+    health = {
+        "gpt-test": ProviderHealthSnapshot("gpt-test", blocked=True),
+    }
+    selected = select_unblocked(rank_remote_candidates(registry, health), limit=10)
+    assert all(item.model != "gpt-test" for item in selected)
+
+
+def test_reason_explicitly_preserves_verification_boundary():
+    registry = _registry()
+    ranked = rank_remote_candidates(registry, {})
+    assert ranked
+    assert "verification" in ranked[0].reason

--- a/tests/garvis/test_universal_ai_router_security.py
+++ b/tests/garvis/test_universal_ai_router_security.py
@@ -1,0 +1,94 @@
+import json
+
+from garvis.universal_ai_registry import (
+    AdapterKind,
+    Authority,
+    CandidateType,
+    build_registry,
+    identify_provider,
+    remote_model_organ,
+)
+
+
+def test_unknown_provider_fails_closed():
+    for model in (
+        "claudeevil",
+        "anthropicevil/model",
+        "grokish/model",
+        "totally-unknown-model",
+        "vendor/model",
+        "../model",
+        "openai-ish/model",
+    ):
+        identity = identify_provider(model)
+        assert identity.provider_id == "unknown"
+        assert identity.adapter is AdapterKind.UNKNOWN
+        assert identity.adapter_supported is False
+
+
+def test_unknown_provider_is_never_programmable_even_with_openai_key():
+    organ = remote_model_organ(
+        "totally-unknown-model",
+        env={"OPENAI_API_KEY": "secret"},
+    )
+    assert organ.provider_id == "unknown"
+    assert organ.programmable is False
+    assert organ.adapter_supported is False
+    assert organ.authority is Authority.CANDIDATE_ONLY
+
+
+def test_explicit_openai_names_still_route_to_openai():
+    for model in (
+        "openai/gpt-test",
+        "gpt-5.1",
+        "gpt-4.1",
+        "o1",
+        "o3-mini",
+        "o4-mini",
+    ):
+        identity = identify_provider(model)
+        assert identity.provider_id == "openai"
+        assert identity.adapter is AdapterKind.OPENAI_NATIVE
+        assert identity.adapter_supported is True
+
+
+def test_known_provider_families_still_route():
+    expected = {
+        "anthropic/claude-test": "anthropic",
+        "claude-sonnet-test": "anthropic",
+        "claude/test": "anthropic",
+        "grok/test": "xai",
+        "groq/test": "groq",
+        "openrouter/test": "openrouter",
+        "compatible/test": "compatible",
+        "gemini/test": "gemini",
+    }
+    for model, provider in expected.items():
+        assert identify_provider(model).provider_id == provider
+
+
+def test_environment_presence_does_not_create_provider_identity():
+    registry = build_registry(
+        ["totally-unknown-model"],
+        env={
+            "OPENAI_API_KEY": "secret-openai",
+            "ANTHROPIC_API_KEY": "secret-anthropic",
+            "XAI_API_KEY": "secret-xai",
+        },
+    )
+    remotes = [
+        o for o in registry.all()
+        if o.candidate_type is CandidateType.REMOTE_API
+    ]
+    assert len(remotes) == 1
+    assert remotes[0].provider_id == "unknown"
+    assert remotes[0].programmable is False
+
+
+def test_safe_report_does_not_leak_configuration_values():
+    registry = build_registry(
+        ["openai/gpt-test", "totally-unknown-model"],
+        env={"OPENAI_API_KEY": "very-secret-value"},
+    )
+    encoded = json.dumps(registry.safe_report(), sort_keys=True)
+    assert "very-secret-value" not in encoded

--- a/tests/garvis/test_universal_ai_router_security.py
+++ b/tests/garvis/test_universal_ai_router_security.py
@@ -32,6 +32,7 @@ def test_unknown_provider_is_never_programmable_even_with_openai_key():
         env={"OPENAI_API_KEY": "secret"},
     )
     assert organ.provider_id == "unknown"
+    assert organ.configured is False
     assert organ.programmable is False
     assert organ.adapter_supported is False
     assert organ.authority is Authority.CANDIDATE_ONLY

--- a/tests/garvis/test_universal_ai_router_security.py
+++ b/tests/garvis/test_universal_ai_router_security.py
@@ -4,6 +4,7 @@ from garvis.universal_ai_registry import (
     AdapterKind,
     Authority,
     CandidateType,
+    android_app_organ,
     build_registry,
     identify_provider,
     remote_model_organ,
@@ -93,3 +94,16 @@ def test_safe_report_does_not_leak_configuration_values():
     )
     encoded = json.dumps(registry.safe_report(), sort_keys=True)
     assert "very-secret-value" not in encoded
+
+def test_android_app_cannot_self_declare_programmable_adapter():
+    manual = android_app_organ("com.example.manual")
+    assert manual.programmable is False
+    assert manual.adapter_supported is False
+    assert manual.adapter is AdapterKind.MANUAL_ONLY
+
+    try:
+        android_app_organ("com.example.unverified", programmable=True)
+    except ValueError as exc:
+        assert "verified integration adapter" in str(exc)
+    else:
+        raise AssertionError("unverified Android app became programmable")


### PR DESCRIPTION
## Summary

Adds the security-reviewed **GARVIS Universal AI Router V1.1**.

Creator / conceptual architect: **Adrien D. Thomas**

GARVIS remains the orchestrator. External AI providers remain candidate reasoning organs rather than truth, identity, integration, or execution authorities.

## Core boundaries

- `001 Context` → GARVIS
- `100 Evidence` → GARVIS evidence
- `111 Integration` → GARVIS
- External provider output → `CANDIDATE_ONLY`
- Unknown provider identity → fail closed / not configured / not programmable
- Environment configuration → availability metadata only
- Provider health → routing evidence, not a truth score
- Installed Android app presence → manual-only metadata unless a separately verified integration adapter is approved

## Validation

Final reviewed head: `278aae7ffb8595753cf2c4f06f3381816c6cbdf8`

- 31 focused Router tests passed
- 541 GARVIS tests + 3 subtests passed
- Repository Ruff passed
- Diff/whitespace integrity passed
- Secret scan passed
- Repository guard passed
- GitHub Guard workflow passed
- GitHub Tests workflow passed
- Security Review completed with 0 CRITICAL and 0 HIGH findings

Review hardening closed two independently reproduced findings:

- `select_unblocked(..., limit <= 0)` now returns an empty selection.
- Installed Android apps cannot self-declare a programmable/internal adapter without a separately verified integration.

## Review disposition

The remaining CodeRabbit recommendation for a full Agents SDK multi-agent control plane is intentionally **deferred from V1.1**.

It is treated as future architecture work, not a defect in this metadata/router release.

A future separately governed stage may specify and test:

- Agent / Runner orchestration
- bounded execution and `max_turns`
- approved tools and command guardrails
- persistent session/history storage
- controlled agent handoffs
- external-provider execution
- device-control integration

None of those execution capabilities are introduced or authorized by PR #79.

## Governance

Recorded approvals:

- **APPROVE GARVIS UNIVERSAL AI ROUTER V1.1 PR STAGE**
- **APPROVE GARVIS UNIVERSAL AI ROUTER V1.1 READY FOR REVIEW STAGE**
- **APPROVE GARVIS UNIVERSAL AI ROUTER V1.1 REVIEW FIX COMMIT PUSH STAGE**
- **APPROVE GARVIS UNIVERSAL AI ROUTER V1.1 REVIEW DISPOSITION AND PR METADATA STAGE**

PR #79 is ready for review and remains **unmerged**.

- Merge: **NOT authorized**
- Deployment: **NOT authorized**
- Real external AI provider calls: **NOT authorized**
- Device-control permissions: **NOT authorized**
