### PR TITLE
garvis: add Abaddon Scout V1 prototype

### DIFF
--- a/docs/security/ABADDON_SCOUT_V1_CONSENT_LEDGER.md
+++ b/docs/security/ABADDON_SCOUT_V1_CONSENT_LEDGER.md
@@ -1,0 +1,51 @@
+# Abaddon Scout V1 Consent Ledger
+
+## Authority holder
+
+Adrien Daryl Thomas, also identified as Adrien D. Thomas.
+
+## Approved prototype stage
+
+Approved base commit:
+
+`fe815470b0f6cb9ae68f11a4d2220c8ef9efa962`
+
+Approved branch:
+
+`prototype/abaddon-scout-v1-20260805`
+
+Approved files:
+
+- `src/garvis/abaddon_scout.py`
+- `tests/garvis/test_abaddon_scout.py`
+- `docs/security/ABADDON_SCOUT_V1_MISSION_BRIEF.md`
+- `docs/security/ABADDON_SCOUT_V1_CONSENT_LEDGER.md`
+
+Approved activities:
+
+- Creation of one isolated local worktree
+- Creation of exactly the four listed files
+- Temporary-fixture evidence tests
+- Path-containment and symbolic-link escape tests
+- SHA-256 manifest tests
+- `REPORT.json` generation tests
+- Scout ZIP generation tests
+- Syntax and scoped static-security checks
+
+## Explicitly not authorized
+
+- Examination of the real evidence package
+- Access to account or platform records
+- Network activity or external synchronization
+- Messages, uploads, emails, support submissions, or legal submissions
+- Deletion or alteration of protected evidence
+- Installation or purchasing
+- Git staging, commit, push, or pull-request activity
+- Reviewer responses, merge, or deployment
+- Modification of protected systems
+
+## Stage transition rule
+
+A later real-evidence examination requires a new, explicit authorization that
+identifies the evidence root, output destination, expected actions, and
+completion gate.

--- a/docs/security/ABADDON_SCOUT_V1_MISSION_BRIEF.md
+++ b/docs/security/ABADDON_SCOUT_V1_MISSION_BRIEF.md
@@ -1,0 +1,43 @@
+# Abaddon Scout V1 Mission Brief
+
+**Creator attribution:** Adrien D. Thomas
+
+**Project:** GARVIS / Abaddon / Hypercube Heartbeat / ADOEG evidence workflow
+
+**Prototype date:** 2026-08-05
+
+## Mission
+
+Abaddon Scout V1 is a bounded, read-only evidence examiner. It processes only
+the evidence directory explicitly supplied by its operator.
+
+The Scout records relative paths, byte sizes, SHA-256 digests, supplied
+expectations, missing expected files, mismatches, and unresolved evidence. It
+can produce `REPORT.json`, `manifest.sha256`, and a deterministic evidence ZIP.
+
+## Containment rules
+
+1. The Scout must not search outside the supplied evidence root.
+2. Absolute paths, parent traversal, and symbolic links are rejected.
+3. The output directory must remain outside the evidence root.
+4. Importing the module must not execute a scan or create files.
+5. The Scout has no network, account, email, GitHub, messaging, deletion,
+   installation, purchasing, or protected-system capability.
+6. Output files are created only by an explicit package-generation call.
+7. Existing output files are never overwritten.
+8. Evidence changes during packaging cause a fail-closed result.
+
+## Claim boundaries
+
+A matching SHA-256 digest verifies that examined bytes match a supplied digest.
+It does not independently prove authorship, ownership, infringement, platform
+conduct, scientific validity, historical custody, or account activity.
+
+The Scout must preserve missing evidence, contradictions, and uncertainty
+rather than infer unsupported conclusions.
+
+## Prototype boundary
+
+This four-file prototype may be tested only with temporary fixtures. It is not
+authorized to inspect Adrien D. Thomas's real evidence package during this
+stage.

--- a/src/garvis/abaddon_scout.py
+++ b/src/garvis/abaddon_scout.py
@@ -1,0 +1,383 @@
+"""Bounded, read-only evidence examiner for the GARVIS project.
+
+Abaddon Scout V1 examines only an explicitly supplied evidence directory.
+Importing this module performs no scan, file creation, network operation,
+message transmission, Git operation, or protected-system action.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import zipfile
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath
+
+SCHEMA = "procityhub.garvis.abaddon-scout-report.v1"
+REPORT_NAME = "REPORT.json"
+MANIFEST_NAME = "manifest.sha256"
+ARCHIVE_NAME = "ABADDON_SCOUT_V1.zip"
+ZIP_TIMESTAMP = (1980, 1, 1, 0, 0, 0)
+BUFFER_SIZE = 1024 * 1024
+
+
+class ScoutError(RuntimeError):
+    """Base exception for a bounded Scout failure."""
+
+
+class ContainmentError(ScoutError):
+    """Raised when a path escapes or weakens the approved evidence boundary."""
+
+
+class OutputCollisionError(ScoutError):
+    """Raised when a Scout output would overwrite an existing file."""
+
+
+class EvidenceChangedError(ScoutError):
+    """Raised when evidence changes between examination and packaging."""
+
+
+def _is_within(path: Path, root: Path) -> bool:
+    return path == root or root in path.parents
+
+
+def _normalize_relative_path(value: str) -> str:
+    if not value or "\x00" in value or "\\" in value:
+        raise ContainmentError(f"invalid relative evidence path: {value!r}")
+
+    raw_parts = value.split("/")
+    if any(part in {"", ".", ".."} for part in raw_parts):
+        raise ContainmentError(f"unsafe relative evidence path: {value!r}")
+
+    candidate = PurePosixPath(value)
+    if candidate.is_absolute():
+        raise ContainmentError(f"absolute evidence path is prohibited: {value!r}")
+
+    return candidate.as_posix()
+
+
+def _normalize_expected(
+    expected_hashes: Mapping[str, str] | None,
+) -> dict[str, str]:
+    normalized: dict[str, str] = {}
+
+    for raw_path, raw_digest in (expected_hashes or {}).items():
+        relative = _normalize_relative_path(str(raw_path))
+        digest = str(raw_digest).lower()
+
+        if len(digest) != 64 or any(char not in "0123456789abcdef" for char in digest):
+            raise ScoutError(f"invalid SHA-256 digest for {relative!r}")
+
+        if relative in normalized:
+            raise ScoutError(f"duplicate expected path: {relative!r}")
+
+        normalized[relative] = digest
+
+    return normalized
+
+
+def _resolve_evidence_root(evidence_root: str | Path) -> Path:
+    supplied = Path(evidence_root).expanduser()
+
+    if supplied.is_symlink():
+        raise ContainmentError("the evidence root itself may not be a symbolic link")
+
+    try:
+        resolved = supplied.resolve(strict=True)
+    except FileNotFoundError as exc:
+        raise ScoutError(f"evidence root does not exist: {supplied}") from exc
+
+    if not resolved.is_dir():
+        raise ScoutError(f"evidence root is not a directory: {resolved}")
+
+    return resolved
+
+
+def _iter_evidence_files(root: Path) -> list[Path]:
+    discovered: list[Path] = []
+
+    for current, directory_names, file_names in os.walk(
+        root,
+        topdown=True,
+        followlinks=False,
+    ):
+        current_path = Path(current)
+
+        for directory_name in sorted(directory_names):
+            directory = current_path / directory_name
+            if directory.is_symlink():
+                raise ContainmentError(
+                    f"symbolic-link directory is prohibited: "
+                    f"{directory.relative_to(root).as_posix()}"
+                )
+
+        directory_names[:] = sorted(directory_names)
+
+        for file_name in sorted(file_names):
+            file_path = current_path / file_name
+
+            if file_path.is_symlink():
+                raise ContainmentError(
+                    f"symbolic-link file is prohibited: "
+                    f"{file_path.relative_to(root).as_posix()}"
+                )
+
+            try:
+                resolved = file_path.resolve(strict=True)
+            except FileNotFoundError as exc:
+                raise ScoutError(f"evidence file disappeared: {file_path}") from exc
+
+            if not _is_within(resolved, root):
+                raise ContainmentError(f"evidence path escaped the root: {file_path}")
+
+            if resolved.is_file():
+                discovered.append(resolved)
+
+    return sorted(discovered, key=lambda item: item.relative_to(root).as_posix())
+
+
+def sha256_file(path: str | Path) -> str:
+    digest = hashlib.sha256()
+
+    with Path(path).open("rb") as handle:
+        while chunk := handle.read(BUFFER_SIZE):
+            digest.update(chunk)
+
+    return digest.hexdigest()
+
+
+def scan_evidence(
+    evidence_root: str | Path,
+    expected_hashes: Mapping[str, str] | None = None,
+) -> dict[str, object]:
+    """Examine files contained by one explicitly supplied evidence root."""
+
+    root = _resolve_evidence_root(evidence_root)
+    expected = _normalize_expected(expected_hashes)
+    entries: list[dict[str, object]] = []
+    actual_paths: set[str] = set()
+    contradictions: list[dict[str, str]] = []
+
+    for file_path in _iter_evidence_files(root):
+        relative = file_path.relative_to(root).as_posix()
+        actual_digest = sha256_file(file_path)
+        expected_digest = expected.get(relative)
+
+        if expected_digest is None:
+            status = "unverified"
+        elif expected_digest == actual_digest:
+            status = "verified"
+        else:
+            status = "mismatch"
+            contradictions.append(
+                {
+                    "path": relative,
+                    "expected_sha256": expected_digest,
+                    "actual_sha256": actual_digest,
+                }
+            )
+
+        actual_paths.add(relative)
+        entries.append(
+            {
+                "path": relative,
+                "size_bytes": file_path.stat().st_size,
+                "sha256": actual_digest,
+                "verification_status": status,
+            }
+        )
+
+    missing_expected = sorted(set(expected) - actual_paths)
+    verified_count = sum(
+        item["verification_status"] == "verified" for item in entries
+    )
+    mismatch_count = sum(
+        item["verification_status"] == "mismatch" for item in entries
+    )
+    unverified_count = sum(
+        item["verification_status"] == "unverified" for item in entries
+    )
+
+    return {
+        "schema": SCHEMA,
+        "evidence_root_label": root.name,
+        "files": entries,
+        "expected_file_count": len(expected),
+        "observed_file_count": len(entries),
+        "verified_file_count": verified_count,
+        "mismatch_file_count": mismatch_count,
+        "unverified_file_count": unverified_count,
+        "missing_expected_files": missing_expected,
+        "contradictions": contradictions,
+        "claim_boundaries": [
+            "The Scout records files supplied inside the approved evidence root.",
+            "A SHA-256 match verifies byte identity against the supplied digest.",
+            "A hash alone does not prove authorship, ownership, infringement, "
+            "platform conduct, scientific validity, or historical custody.",
+            "Missing or conflicting evidence remains explicitly unresolved.",
+            "The Scout has no access to account records or platform systems.",
+        ],
+    }
+
+
+def _manifest_bytes(report: Mapping[str, object]) -> bytes:
+    lines = [
+        f"{entry['sha256']}  {entry['path']}"
+        for entry in report["files"]  # type: ignore[index]
+    ]
+    text = "\n".join(lines)
+    if text:
+        text += "\n"
+    return text.encode("utf-8")
+
+
+def _zip_info(name: str) -> zipfile.ZipInfo:
+    info = zipfile.ZipInfo(name, ZIP_TIMESTAMP)
+    info.compress_type = zipfile.ZIP_DEFLATED
+    info.create_system = 3
+    info.external_attr = 0o100644 << 16
+    return info
+
+
+def _write_verified_evidence_member(
+    archive: zipfile.ZipFile,
+    root: Path,
+    entry: Mapping[str, object],
+) -> None:
+    relative = str(entry["path"])
+    expected_digest = str(entry["sha256"])
+    source = root / relative
+    resolved = source.resolve(strict=True)
+
+    if source.is_symlink() or not _is_within(resolved, root):
+        raise ContainmentError(f"evidence path changed containment: {relative}")
+
+    digest = hashlib.sha256()
+    info = _zip_info(f"evidence/{relative}")
+
+    with source.open("rb") as input_handle:
+        with archive.open(info, "w") as output_handle:
+            while chunk := input_handle.read(BUFFER_SIZE):
+                digest.update(chunk)
+                output_handle.write(chunk)
+
+    if digest.hexdigest() != expected_digest:
+        raise EvidenceChangedError(
+            f"evidence changed during package generation: {relative}"
+        )
+
+
+def build_scout_package(
+    evidence_root: str | Path,
+    output_dir: str | Path,
+    expected_hashes: Mapping[str, str] | None = None,
+    *,
+    generated_at: str | None = None,
+    creator: str = "Adrien D. Thomas",
+) -> dict[str, str]:
+    """Generate REPORT.json, manifest.sha256, and a deterministic Scout ZIP."""
+
+    root = _resolve_evidence_root(evidence_root)
+    output_supplied = Path(output_dir).expanduser()
+
+    if output_supplied.is_symlink():
+        raise ContainmentError("the output directory may not be a symbolic link")
+
+    output_candidate = output_supplied.resolve(strict=False)
+    if _is_within(output_candidate, root):
+        raise ContainmentError("the Scout output directory must be outside evidence")
+
+    output_supplied.mkdir(parents=True, exist_ok=True)
+    output = output_supplied.resolve(strict=True)
+
+    if output.is_symlink() or not output.is_dir():
+        raise ContainmentError("invalid Scout output directory")
+
+    report_path = output / REPORT_NAME
+    manifest_path = output / MANIFEST_NAME
+    archive_path = output / ARCHIVE_NAME
+
+    for target in (report_path, manifest_path, archive_path):
+        if target.exists() or target.is_symlink():
+            raise OutputCollisionError(f"Scout output already exists: {target}")
+
+    report = scan_evidence(root, expected_hashes)
+    report["creator"] = creator
+    report["generated_at"] = generated_at or datetime.now(
+        timezone.utc
+    ).isoformat().replace("+00:00", "Z")
+    report["package_contents"] = [
+        REPORT_NAME,
+        MANIFEST_NAME,
+        ARCHIVE_NAME,
+    ]
+
+    report_bytes = (
+        json.dumps(report, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+    ).encode("utf-8")
+    manifest_bytes = _manifest_bytes(report)
+
+    with zipfile.ZipFile(
+        archive_path,
+        mode="x",
+        compression=zipfile.ZIP_DEFLATED,
+        compresslevel=9,
+    ) as archive:
+        for entry in report["files"]:  # type: ignore[index]
+            _write_verified_evidence_member(archive, root, entry)
+
+        archive.writestr(_zip_info(REPORT_NAME), report_bytes)
+        archive.writestr(_zip_info(MANIFEST_NAME), manifest_bytes)
+
+    report_path.write_bytes(report_bytes)
+    manifest_path.write_bytes(manifest_bytes)
+
+    return {
+        "report": str(report_path),
+        "manifest": str(manifest_path),
+        "archive": str(archive_path),
+        "archive_sha256": sha256_file(archive_path),
+    }
+
+
+def _load_expected_json(path: str | Path | None) -> dict[str, str]:
+    if path is None:
+        return {}
+
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ScoutError("expected-hash JSON must contain an object")
+
+    return {str(key): str(value) for key, value in payload.items()}
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build a bounded Abaddon Scout V1 evidence package."
+    )
+    parser.add_argument("evidence_root")
+    parser.add_argument("output_dir")
+    parser.add_argument("--expected-json")
+    parser.add_argument("--generated-at")
+    parser.add_argument("--creator", default="Adrien D. Thomas")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = _build_parser().parse_args(argv)
+    result = build_scout_package(
+        arguments.evidence_root,
+        arguments.output_dir,
+        _load_expected_json(arguments.expected_json),
+        generated_at=arguments.generated_at,
+        creator=arguments.creator,
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/garvis/test_abaddon_scout.py
+++ b/tests/garvis/test_abaddon_scout.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import os
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from garvis.abaddon_scout import (
+    ARCHIVE_NAME,
+    MANIFEST_NAME,
+    REPORT_NAME,
+    ContainmentError,
+    build_scout_package,
+    scan_evidence,
+    sha256_file,
+)
+
+SOURCE = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "garvis"
+    / "abaddon_scout.py"
+)
+FIXED_TIME = "2026-08-05T17:00:00Z"
+
+
+def digest(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def test_import_has_no_filesystem_side_effects(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    before = set(tmp_path.iterdir())
+    module_name = "garvis_abaddon_scout_import_safety_test"
+    spec = importlib.util.spec_from_file_location(module_name, SOURCE)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(module_name, None)
+
+    assert set(tmp_path.iterdir()) == before
+
+
+def test_scan_hashes_files_in_deterministic_path_order(tmp_path: Path) -> None:
+    root = tmp_path / "evidence"
+    root.mkdir()
+    (root / "z.txt").write_bytes(b"z")
+    (root / "a.txt").write_bytes(b"a")
+
+    report = scan_evidence(root, {"a.txt": digest(b"a")})
+
+    assert [item["path"] for item in report["files"]] == ["a.txt", "z.txt"]
+    assert report["files"][0]["verification_status"] == "verified"
+    assert report["files"][1]["verification_status"] == "unverified"
+    assert report["observed_file_count"] == 2
+
+
+def test_scan_rejects_symbolic_link_escape(tmp_path: Path) -> None:
+    root = tmp_path / "evidence"
+    root.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("outside", encoding="utf-8")
+    link = root / "escape.txt"
+
+    try:
+        os.symlink(outside, link)
+    except (NotImplementedError, OSError):
+        pytest.skip("symbolic links are unavailable on this filesystem")
+
+    with pytest.raises(ContainmentError):
+        scan_evidence(root)
+
+
+def test_expected_hash_path_traversal_is_rejected(tmp_path: Path) -> None:
+    root = tmp_path / "evidence"
+    root.mkdir()
+
+    with pytest.raises(ContainmentError):
+        scan_evidence(root, {"../outside.txt": "0" * 64})
+
+
+def test_missing_and_mismatched_expected_evidence_is_preserved(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "evidence"
+    root.mkdir()
+    (root / "present.txt").write_bytes(b"actual")
+
+    report = scan_evidence(
+        root,
+        {
+            "present.txt": digest(b"different"),
+            "missing.txt": digest(b"missing"),
+        },
+    )
+
+    assert report["mismatch_file_count"] == 1
+    assert report["missing_expected_files"] == ["missing.txt"]
+    assert report["contradictions"] == [
+        {
+            "path": "present.txt",
+            "expected_sha256": digest(b"different"),
+            "actual_sha256": digest(b"actual"),
+        }
+    ]
+
+
+def test_package_contains_report_manifest_and_evidence(tmp_path: Path) -> None:
+    root = tmp_path / "evidence"
+    output = tmp_path / "output"
+    nested = root / "nested"
+    nested.mkdir(parents=True)
+    (root / "alpha.txt").write_bytes(b"alpha")
+    (nested / "beta.bin").write_bytes(b"\x00\x01beta")
+
+    result = build_scout_package(
+        root,
+        output,
+        {
+            "alpha.txt": digest(b"alpha"),
+            "nested/beta.bin": digest(b"\x00\x01beta"),
+        },
+        generated_at=FIXED_TIME,
+    )
+
+    report = json.loads((output / REPORT_NAME).read_text(encoding="utf-8"))
+    manifest = (output / MANIFEST_NAME).read_text(encoding="utf-8")
+
+    assert report["creator"] == "Adrien D. Thomas"
+    assert report["generated_at"] == FIXED_TIME
+    assert report["verified_file_count"] == 2
+    beta_digest = digest(b"\x00\x01beta")
+    assert manifest == (
+        f"{digest(b'alpha')}  alpha.txt\n"
+        f"{beta_digest}  nested/beta.bin\n"
+    )
+    assert result["archive_sha256"] == sha256_file(output / ARCHIVE_NAME)
+
+    with zipfile.ZipFile(output / ARCHIVE_NAME) as archive:
+        assert archive.namelist() == [
+            "evidence/alpha.txt",
+            "evidence/nested/beta.bin",
+            REPORT_NAME,
+            MANIFEST_NAME,
+        ]
+        assert archive.read("evidence/alpha.txt") == b"alpha"
+        assert archive.read("evidence/nested/beta.bin") == b"\x00\x01beta"
+        assert archive.read(REPORT_NAME) == (output / REPORT_NAME).read_bytes()
+        assert archive.read(MANIFEST_NAME) == (output / MANIFEST_NAME).read_bytes()
+
+
+def test_package_archive_is_deterministic_with_fixed_metadata(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "evidence"
+    root.mkdir()
+    (root / "proof.txt").write_bytes(b"proof")
+
+    first = build_scout_package(
+        root,
+        tmp_path / "first",
+        generated_at=FIXED_TIME,
+    )
+    second = build_scout_package(
+        root,
+        tmp_path / "second",
+        generated_at=FIXED_TIME,
+    )
+
+    assert first["archive_sha256"] == second["archive_sha256"]
+    assert Path(first["archive"]).read_bytes() == Path(second["archive"]).read_bytes()
+
+
+def test_output_directory_inside_evidence_is_rejected(tmp_path: Path) -> None:
+    root = tmp_path / "evidence"
+    root.mkdir()
+
+    with pytest.raises(ContainmentError):
+        build_scout_package(root, root / "scout-output", generated_at=FIXED_TIME)

--- a/tests/garvis/test_abaddon_scout.py
+++ b/tests/garvis/test_abaddon_scout.py
@@ -7,6 +7,7 @@ import os
 import sys
 import zipfile
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -61,10 +62,11 @@ def test_scan_hashes_files_in_deterministic_path_order(tmp_path: Path) -> None:
     (root / "a.txt").write_bytes(b"a")
 
     report = scan_evidence(root, {"a.txt": digest(b"a")})
+    files = cast(list[dict[str, object]], report["files"])
 
-    assert [item["path"] for item in report["files"]] == ["a.txt", "z.txt"]
-    assert report["files"][0]["verification_status"] == "verified"
-    assert report["files"][1]["verification_status"] == "unverified"
+    assert [item["path"] for item in files] == ["a.txt", "z.txt"]
+    assert files[0]["verification_status"] == "verified"
+    assert files[1]["verification_status"] == "unverified"
     assert report["observed_file_count"] == 2
 
 


### PR DESCRIPTION
Creator attribution: Adrien D. Thomas

## Scope

This pull request adds the isolated, read-only Abaddon Scout V1 prototype:

- `src/garvis/abaddon_scout.py`
- `tests/garvis/test_abaddon_scout.py`
- `docs/security/ABADDON_SCOUT_V1_MISSION_BRIEF.md`
- `docs/security/ABADDON_SCOUT_V1_CONSENT_LEDGER.md`

## Verification

- Eight scoped temporary-fixture tests passed.
- Python syntax checks passed.
- Ruff passed.
- Scoped static-security checks passed.
- Path traversal and symbolic-link escapes are rejected.
- Report, SHA-256 manifest, and ZIP generation were tested only with temporary fixtures.

## Boundaries

Importing or storing this prototype does not scan Adrien D. Thomas's real evidence package. It grants no account access, messaging, deployment, deletion, purchasing, or protected-system authority.