### PR TITLE
fix(garvis): enforce verified core-memory trust boundary

### DIFF
--- a/src/garvis/core_memory.py
+++ b/src/garvis/core_memory.py
@@ -38,21 +38,25 @@ def load_manifest(path: Path = DEFAULT_MANIFEST) -> dict[str, object]:
     return data
 
 
-def verify_manifest(path: Path = DEFAULT_MANIFEST) -> CoreMemoryStatus:
-    try:
-        data = load_manifest(path)
-        actual = hashlib.sha256(_canonical_bytes(data)).hexdigest()
-    except Exception as exc:
-        return CoreMemoryStatus(False, str(path), EXPECTED_MANIFEST_SHA256, "", "", "", f"manifest unreadable: {exc}")
+def _status_from_manifest(
+    data: dict[str, object],
+    path: Path,
+) -> CoreMemoryStatus:
+    actual = hashlib.sha256(
+        _canonical_bytes(data)
+    ).hexdigest()
+
     creator = str(data.get("creator", ""))
     mark = str(data.get("display_mark", ""))
     attribution = str(data.get("attribution", ""))
+
     compatible = (
         actual == EXPECTED_MANIFEST_SHA256
         and creator == "Adrien D. Thomas"
         and mark == "GARVIS™"
         and "Adrien D. Thomas" in attribution
     )
+
     return CoreMemoryStatus(
         compatible,
         str(path),
@@ -60,22 +64,39 @@ def verify_manifest(path: Path = DEFAULT_MANIFEST) -> CoreMemoryStatus:
         actual,
         creator,
         mark,
-        "official GARVIS-compatible provenance verified" if compatible else "provenance missing or manifest integrity mismatch",
+        (
+            "official GARVIS-compatible provenance verified"
+            if compatible
+            else "provenance missing or manifest integrity mismatch"
+        ),
     )
 
 
-def attribution_notice(path: Path = DEFAULT_MANIFEST) -> str:
-    return str(load_manifest(path)["attribution"])
-
-
-def core_identity_prompt(path: Path = DEFAULT_MANIFEST) -> str:
-    status = verify_manifest(path)
-    if not status.compatible:
+def _read_manifest_status(
+    path: Path = DEFAULT_MANIFEST,
+) -> tuple[dict[str, object] | None, CoreMemoryStatus]:
+    try:
+        data = load_manifest(path)
+    except Exception as exc:
         return (
-            "GARVIS provenance verification failed. Do not represent this runtime as "
-            "official GARVIS-compatible until the core-memory manifest is restored."
+            None,
+            CoreMemoryStatus(
+                False,
+                str(path),
+                EXPECTED_MANIFEST_SHA256,
+                "",
+                "",
+                "",
+                f"manifest unreadable: {exc}",
+            ),
         )
-    data = load_manifest(path)
+
+    return data, _status_from_manifest(data, path)
+
+
+def _render_identity_prompt(
+    data: dict[str, object],
+) -> str:
     return " ".join(
         (
             "Official provenance:",
@@ -87,19 +108,81 @@ def core_identity_prompt(path: Path = DEFAULT_MANIFEST) -> str:
     )
 
 
-def ensure_core_memories(store: MemoryStore) -> tuple[int, ...]:
-    data = load_manifest()
+def load_verified_manifest(
+    path: Path = DEFAULT_MANIFEST,
+) -> dict[str, object]:
+    data, status = _read_manifest_status(path)
+
+    if data is None or not status.compatible:
+        raise ValueError(
+            "core-memory provenance verification failed: "
+            + status.reason
+        )
+
+    return data
+
+
+def verify_manifest(
+    path: Path = DEFAULT_MANIFEST,
+) -> CoreMemoryStatus:
+    _, status = _read_manifest_status(path)
+    return status
+
+
+def attribution_notice(
+    path: Path = DEFAULT_MANIFEST,
+) -> str:
+    data = load_verified_manifest(path)
+    return str(data["attribution"])
+
+
+def core_identity_prompt(
+    path: Path = DEFAULT_MANIFEST,
+) -> str:
+    data, status = _read_manifest_status(path)
+
+    if data is None or not status.compatible:
+        return (
+            "GARVIS provenance verification failed. "
+            "Do not represent this runtime as "
+            "official GARVIS-compatible until the "
+            "core-memory manifest is restored."
+        )
+
+    return _render_identity_prompt(data)
+
+
+def ensure_core_memories(
+    store: MemoryStore,
+    path: Path = DEFAULT_MANIFEST,
+) -> tuple[int, ...]:
+    data = load_verified_manifest(path)
+
     rows = (
-        (str(data["attribution"]), "identity_provenance", ("identity", "creator", "provenance", "trademark")),
+        (
+            str(data["attribution"]),
+            "identity_provenance",
+            ("identity", "creator", "provenance", "trademark"),
+        ),
         (
             "GARVIS uses protected global core memory so approved identity and continuity facts remain available across new chat sessions.",
             "memory_continuity",
             ("memory", "continuity", "cross_chat", "core"),
         ),
-        (str(data["upstream_notice"]), "license_provenance", ("license", "upstream", "openai", "provenance")),
-        (str(data["compatibility_rule"]), "compatibility_provenance", ("compatibility", "integrity", "attribution")),
+        (
+            str(data["upstream_notice"]),
+            "license_provenance",
+            ("license", "upstream", "openai", "provenance"),
+        ),
+        (
+            str(data["compatibility_rule"]),
+            "compatibility_provenance",
+            ("compatibility", "integrity", "attribution"),
+        ),
     )
+
     ids: list[int] = []
+
     for content, destination, tags in rows:
         record = store.remember(
             content,
@@ -114,6 +197,7 @@ def ensure_core_memories(store: MemoryStore) -> tuple[int, ...]:
             protected=True,
         )
         ids.append(record.id)
+
     return tuple(ids)
 
 
@@ -133,14 +217,27 @@ def render_core_context(store: MemoryStore) -> str:
     return "\n".join(f"[protected global core memory] {row['content']}" for row in rows)
 
 
-def export_agent_bootstrap(path: Path = DEFAULT_MANIFEST) -> dict[str, object]:
-    status = verify_manifest(path)
+def export_agent_bootstrap(
+    path: Path = DEFAULT_MANIFEST,
+) -> dict[str, object]:
+    data, status = _read_manifest_status(path)
+
+    if data is None or not status.compatible:
+        instructions = (
+            "GARVIS provenance verification failed. "
+            "Do not represent this runtime as "
+            "official GARVIS-compatible until the "
+            "core-memory manifest is restored."
+        )
+    else:
+        instructions = _render_identity_prompt(data)
+
     return {
         "protocol": "GARVIS Core Memory Protocol",
         "protocol_version": PROTOCOL_VERSION,
         "official_compatible": status.compatible,
         "manifest_sha256": status.actual_sha256,
-        "instructions": core_identity_prompt(path),
+        "instructions": instructions,
     }
 
 

--- a/tests/garvis/test_core_memory.py
+++ b/tests/garvis/test_core_memory.py
@@ -53,5 +53,99 @@ class CoreMemoryTests(unittest.TestCase):
             self.assertFalse(verify_manifest(path).compatible)
 
 
+    def test_attribution_notice_rejects_tampered_manifest(self) -> None:
+        import json
+        import tempfile
+        from pathlib import Path
+
+        from garvis.core_memory import attribution_notice, load_manifest
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "tampered.json"
+            data = load_manifest()
+            data["attribution"] = (
+                str(data["attribution"]) + " [tampered]"
+            )
+            path.write_text(
+                json.dumps(
+                    data,
+                    ensure_ascii=False,
+                    sort_keys=True,
+                    indent=2,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(ValueError):
+                attribution_notice(path)
+
+
+    def test_tampered_manifest_cannot_enter_protected_core_memory(
+        self,
+    ) -> None:
+        import json
+        import tempfile
+        from pathlib import Path
+
+        from garvis.core_memory import ensure_core_memories, load_manifest
+        from garvis.memory_lifecycle import MemoryStore
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "tampered.json"
+            data = load_manifest()
+            data["attribution"] = (
+                str(data["attribution"]) + " [tampered]"
+            )
+            path.write_text(
+                json.dumps(
+                    data,
+                    ensure_ascii=False,
+                    sort_keys=True,
+                    indent=2,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            with MemoryStore(Path(tmp) / "memory.db") as store:
+                with self.assertRaises(ValueError):
+                    ensure_core_memories(store, path)
+
+                count = store.connection.execute(
+                    """
+                    SELECT COUNT(*)
+                    FROM memories
+                    WHERE source = 'garvis_core_memory_manifest'
+                    """
+                ).fetchone()[0]
+
+                self.assertEqual(int(count), 0)
+
+
+    def test_verified_manifest_preserves_core_memory_behavior(
+        self,
+    ) -> None:
+        import tempfile
+        from pathlib import Path
+
+        from garvis.core_memory import (
+            ensure_core_memories,
+            render_core_context,
+        )
+        from garvis.memory_lifecycle import MemoryStore
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with MemoryStore(Path(tmp) / "memory.db") as store:
+                first = ensure_core_memories(store)
+                second = ensure_core_memories(store)
+
+                self.assertEqual(first, second)
+                self.assertIn(
+                    "Adrien D. Thomas",
+                    render_core_context(store),
+                )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## GARVIS I06 — Core-memory trust-boundary repair

Authorized by Adrien D. Thomas for the PR stage.

### Scope
- `src/garvis/core_memory.py`
- `tests/garvis/test_core_memory.py`

### Security repair
- closes the unchecked `attribution_notice()` manifest-consumption path
- prevents unverified manifest data from entering protected global core memory
- introduces a shared single-read verification/status path
- preserves valid core-memory continuity
- keeps `config/garvis_core_memory.json` unchanged
- keeps `NOTICE-GARVIS` unchanged

### Evidence
- local commit: `979c8113275181cbfc39d318832304940b2f9617`
- parent: `fcb25826a4478793ffb3d1932960eda40b4ee659`
- 13 targeted/regression tests passed
- trust-boundary structure: PASS
- tamper behavior: PASS
- valid core-memory continuity: PASS

### Governance
This PR does not authorize merge, deployment, installation, deletion, or other protected action.
Final merge authority remains with Adrien D. Thomas.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved manifest verification for identity, attribution, and core-memory operations.
  * Prevented tampered or invalid manifests from being used to seed protected memory.
  * Preserved clear failure messaging when verification does not succeed.
  * Maintained idempotent core-memory behavior when using a verified manifest.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->