### PR TITLE
fix(hypercube): repair mypy package and typing boundaries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,8 @@ convention = "google"
 
 [tool.mypy]
 strict = true
+mypy_path = "src"
+explicit_package_bases = true
 disallow_incomplete_defs = false
 disallow_untyped_defs = false
 disallow_untyped_calls = false

--- a/src/hypercube_brain/core.py
+++ b/src/hypercube_brain/core.py
@@ -172,7 +172,7 @@ class HypercubeBrainEngine:
         self.cycle_id = 0
         self.truth = HypercubeTruthEngine()
 
-        self.working = deque(maxlen=working_capacity)
+        self.working: deque[CycleResult] = deque(maxlen=working_capacity)
         self.episodes: list[dict[str, Any]] = []
         self.semantic: dict[str, float] = {}
         self.events: list[dict[str, Any]] = []

--- a/src/hypercube_brain/screen_retina.py
+++ b/src/hypercube_brain/screen_retina.py
@@ -302,7 +302,7 @@ class AndroidScreenRetina:
         stable = 0
         max_error = 0.0
         rounds = 0
-        packets = ()
+        packets: Tuple[VisualNervePacket, ...] = ()
 
         for round_index in range(
             1,

--- a/src/hypercube_brain/visual_pathway.py
+++ b/src/hypercube_brain/visual_pathway.py
@@ -12,7 +12,7 @@ This is a functional software analogy, not a biological simulation.
 from __future__ import annotations
 
 from dataclasses import dataclass, asdict
-from typing import Iterable
+from typing import Any, Iterable
 
 from .core import Observation, clamp01
 
@@ -268,5 +268,5 @@ class VisualPathway:
         )
 
     @staticmethod
-    def describe(percept: CorticalPercept) -> dict:
+    def describe(percept: CorticalPercept) -> dict[str, Any]:
         return asdict(percept)

--- a/tests/hypercube_brain/test_screen_retina.py
+++ b/tests/hypercube_brain/test_screen_retina.py
@@ -23,31 +23,29 @@ class ScreenRetinaTests(
 
     def element(
         self,
-        **overrides,
-    ):
-        data = dict(
-            element_id="send-1",
-            label="Send",
-            role="button",
-            bounds=ScreenBounds(
+        *,
+        element_id: str = "send-1",
+        label: str = "Send",
+        bounds: ScreenBounds | None = None,
+    ) -> ScreenElement:
+        if bounds is None:
+            bounds = ScreenBounds(
                 810,
                 2100,
                 1050,
                 2310,
-            ),
+            )
+
+        return ScreenElement(
+            element_id=element_id,
+            label=label,
+            role="button",
+            bounds=bounds,
             screen_width=1080,
             screen_height=2400,
             confidence=0.98,
             motion=0.0,
             source="android_screen",
-        )
-
-        data.update(
-            overrides
-        )
-
-        return ScreenElement(
-            **data
         )
 
     def test_maps_screen_element_to_visual_nerve(


### PR DESCRIPTION
## Summary
- configure mypy to resolve the src-based Hypercube namespace consistently
- add precise typing to Hypercube working memory, retina packets, and visual-pathway descriptions
- replace the retina test helper's mixed untyped dictionary with typed constructor inputs

## Verification
- strict mypy: 7 Hypercube source/test files, 0 issues
- runtime: 20/20 Hypercube tests passed
- git diff --check: PASS
- security/governance review: PASS
- reviewed commit: 64d7fcc4c43aa6821f109bd7fd59d906187aefae
- base commit: c210476c03ff2e87c2237b0617531ae35b044bcb

No merge or deployment is authorized by this PR creation.