### PR TITLE
fix(garvis): preserve Python 3.9 annotation compatibility

### DIFF
--- a/tools/garvis_resilience.py
+++ b/tools/garvis_resilience.py
@@ -29,6 +29,7 @@ WIRING (three lines in garvis chat loop):
     reply = call_with_retry(client, model, messages)
     ledger.append("assistant", reply)              # before printing
 """
+from __future__ import annotations
 
 import json
 import os


### PR DESCRIPTION
## Summary
- fix the existing Python 3.9 old_versions collection failure
- add only `from __future__ import annotations` to `tools/garvis_resilience.py`
- preserve runtime behavior while postponing annotation evaluation
- keep this repair isolated from PR #98 and PR #97

## Root cause
Python 3.9 eagerly evaluates `str | None`, producing a TypeError during test collection. Postponed annotation evaluation preserves the annotation as a string and restores Python 3.9 compatibility.

## Local verification
- exact one-file transformation: PASS
- Python compile: PASS
- postponed annotation runtime gate: PASS
- resilient-runtime tests: 4/4 PASS
- Ruff: PASS
- git diff --check: PASS
- security/governance review: PASS
- no new capability: PASS
- no authority expansion: PASS
- reviewed commit: 251dde75e2efa538b2cc216c5cf5222ab6069ad0
- base commit: 6ac4ec75ffe569114de69e7e7653355d6d459b8a
- source SHA-256: ca5c3e273a6a8e4ae866d82b1d6f4e55b0d34c232dd9fdac99fea05a6a2d6477

## Epistemic boundary
The Canonical Lattice Law remains HYPOTHESIS UNDER TEST with empirical status NOT_SUPPORTED.
The mathematical identity 1/phi + 1/phi^2 = 1 is preserved.

This PR does not authorize merge, deployment, modification of PR #98, or modification of PR #97.