### PR TITLE
feat: make canonical memory prominent in research reasoning

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,71 @@
+# ProCityHub / GARVIS Architecture
+
+Status: HYPOTHESIS_UNDER_TEST
+
+This document defines the target native ProCityHub architecture. It does not claim that the current repository has completed this migration.
+
+## Canonical domains
+
+GARVIS - product coordination and human-facing interface.
+
+Genesis X - project-defined cognitive processing architecture and heartbeat.
+
+OAB - Observer Actor Bridge connecting observation, bounded action, and termination.
+
+Hypercube - project mathematical, resonance, lattice, and heartbeat research layer.
+
+Evidence - observations, frozen predictions, outcomes, contradictions, and provenance.
+
+Governance - authority, approvals, permissions, policy, and audit.
+
+Capabilities - bounded registry and execution of technically available actions.
+
+Inference - project-controlled protocol boundary for inference implementations.
+
+Interfaces - CLI, Android, voice, API, and other approved human-facing surfaces.
+
+## Authority boundary
+
+No architectural layer silently inherits another layer's authority.
+
+Inference output is candidate material, not truth or governance authority.
+
+Capability does not create authorization.
+
+CAPABILITY IS NOT AUTHORIZATION.
+
+## Genesis X heartbeat
+
+RECEIVE -> SEGMENT -> PREDICT -> VERIFY -> SIMULATE -> PLAN -> OUTPUT -> FEEDBACK -> CONSOLIDATE
+
+## Evidence witness
+
+Raw_Pre -> Frozen_Prediction -> Change_or_Action -> Raw_Post -> Observed_Diff -> Contradiction_Error -> Consolidation
+
+Predictions must not be rewritten after the outcome merely to make the earlier decision appear correct.
+
+## Target package boundary
+
+src/procityhub/garvis/
+src/procityhub/genesis_x/
+src/procityhub/oab/
+src/procityhub/hypercube/
+src/procityhub/evidence/
+src/procityhub/governance/
+src/procityhub/capabilities/
+src/procityhub/inference/
+src/procityhub/interfaces/
+
+## Legacy migration boundary
+
+The current repository still contains legacy external-framework and provider coupling. Useful ProCityHub-owned behavior must be migrated or rewritten before obsolete active paths are removed.
+
+Historical attribution and applicable licence obligations must remain recoverable.
+
+Replacement precedes removal.
+
+## Research boundary
+
+Software tests do not establish AGI, consciousness, ontology, or new physics.
+
+Benchmark results are empirical evidence only and must remain separate from ontological interpretation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable ProCityHub / GARVIS repository changes should be recorded here with truthful scope and provenance.
+
+## Unreleased
+
+### Repository restructuring prototype
+
+- Established the ProCityHub / GARVIS governance foundation.
+- Added creator and ownership boundaries.
+- Added provenance and contribution-evidence rules.
+- Added security and contribution policies.
+- Defined the target native architecture as HYPOTHESIS_UNDER_TEST.
+- Added the Genesis X research and epistemic policy.
+- Added the staged restructuring roadmap.
+
+### Explicitly not completed
+
+- Native runtime migration has not been completed.
+- Legacy external-framework and provider coupling has not yet been removed.
+- Runtime source has not been modified by this prototype.
+- Tests have not yet been modified or executed as the next governance stage.
+- Dependencies and lockfiles have not been changed.
+- GitHub workflows have not been changed.
+- No repository files have been deleted by this prototype.
+- No commit has been created for this prototype.
+- No branch has been pushed.
+- No pull request has been created or modified.
+- No merge has occurred.
+- No deployment or installation has occurred.
+
+### Research status
+
+- The identity 1/phi + 1/phi^2 = 1 remains mathematically VERIFIED.
+- The Canonical Lattice Law C = O^1 * A^(1/phi) * B^(1/phi^2) remains HYPOTHESIS_UNDER_TEST.
+- Current empirical status of the Canonical Lattice Law remains NOT_SUPPORTED unless reproducible evidence changes that classification.
+
+CAPABILITY IS NOT AUTHORIZATION.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,15 @@ All notable ProCityHub / GARVIS repository changes should be recorded here with 
 - Native runtime migration has not been completed.
 - Legacy external-framework and provider coupling has not yet been removed.
 - Runtime source has not been modified by this prototype.
-- Tests have not yet been modified or executed as the next governance stage.
+- Tests were not modified by this prototype; the approved governance-stage static validation was executed and passed.
+- The approved security review was completed with result PROTOTYPE_PASS.
 - Dependencies and lockfiles have not been changed.
 - GitHub workflows have not been changed.
 - No repository files have been deleted by this prototype.
-- No commit has been created for this prototype.
-- No branch has been pushed.
-- No pull request has been created or modified.
+- Reviewed commit d735f78ef8ff0528bee1ac0eac182e323c72ea55 was created.
+- Branch restructure/procityhub-native-20260817 was pushed to the configured GitHub origin.
+- Empty workflow-containment commit 7e614a4fdcedc6f226f44e2d9ea95f6b3ccb5cf6 was created with [skip ci] and changed no files.
+- Draft pull request #101 was created targeting main.
 - No merge has occurred.
 - No deployment or installation has occurred.
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,17 @@
+cff-version: 1.2.0
+message: "If you reference the original ProCityHub/GARVIS project, cite Adrien D. Thomas."
+title: "GARVIS"
+type: software
+authors:
+  - family-names: "Thomas"
+    given-names: "Adrien D."
+    affiliation: "ProCityHub"
+repository-code: "https://github.com/ProCityHub/GARVIS"
+license: MIT
+abstract: "GARVIS is the ProCityHub governed intelligence architecture and research project created and conceptually architected by Adrien D. Thomas."
+keywords:
+  - GARVIS
+  - ProCityHub
+  - Genesis X
+  - Observer Actor Bridge
+  - Hypercube

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Contributing to ProCityHub / GARVIS
+
+GARVIS is created and directed by Adrien D. Thomas / ProCityHub.
+
+## Development pipeline
+
+Research → Specification → Prototype → Tests → Security Review → Pull Request → Merge → Deployment
+
+Approval for one stage does not authorize a later stage.
+
+## Authority boundary
+
+CAPABILITY IS NOT AUTHORIZATION.
+
+Repository access, technical capability, contributor status, reviewer status, CODEOWNERS status, automation status, or use of external tools does not create creator authority, project ownership, merge authority, deployment authority, or permission for protected actions.
+
+## Contribution boundary
+
+A contribution does not confer ownership of the GARVIS project identity, Genesis X, Hypercube Heartbeat, OAB, governance, memory, evidence architecture, or other independent ProCityHub architecture.
+
+Until a counsel-reviewed contribution agreement or copyright-assignment process exists, externally authored implementation code must not enter the canonical ProCityHub-owned implementation where doing so would create unclear ownership, incompatible licensing, or uncertain provenance.
+
+## Provenance requirements
+
+Every substantive contribution should identify its author or source, applicable licence, purpose, files changed, tests performed, security implications, external dependencies, and relevant provenance.
+
+Third-party copyright and licence notices must be preserved when required.
+
+## Research claims
+
+Research claims must distinguish VERIFIED, HYPOTHESIS_UNDER_TEST, and NOT_SUPPORTED.
+
+When required evidence is absent, use NO_RESONANT_ESTIMATE.
+
+## Protected actions
+
+Commit, push, pull-request creation or modification, merge, deployment, installation, deletion, external messaging, purchasing, or protected-system modification remains subject to the applicable explicit approval from Adrien D. Thomas.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,107 @@
+# ProCityHub / GARVIS Governance
+
+## Canonical Creator and Ownership Law
+
+PROCITYHUB / GARVIS CREATOR AND OWNERSHIP LAW
+
+1. CREATOR AND ROOT AUTHORITY
+
+Adrien D. Thomas is the creator, conceptual architect, and final internal
+governance authority of ProCityHub / GARVIS and its original architecture,
+including the project-defined GARVIS, Genesis X, Hypercube Heartbeat, OAB,
+governance, memory, evidence, and related ProCityHub systems, subject to
+documented provenance and applicable law.
+
+2. NO AUTOMATIC CO-OWNERSHIP
+
+No artificial-intelligence provider, model, API, SDK, software library,
+repository host, cloud provider, search service, tool, assistant, or other
+external technology becomes a creator, author, co-owner, partner, agent,
+governance authority, memory owner, or decision authority of ProCityHub /
+GARVIS merely because that technology was used to research, reason, generate
+candidate material, test, document, host, process, compile, or assist with
+the project.
+
+Tool use is not ownership.
+Inference is not authorship authority.
+Hosting is not ownership.
+Dependency is not ownership.
+Assistance is not governance authority.
+
+3. THIRD-PARTY RIGHTS BOUNDARY
+
+Third parties retain only the rights that actually arise from their own
+pre-existing works, applicable licences, contracts, or law.
+
+ProCityHub does not claim authorship of third-party source code or other
+third-party intellectual property.
+
+Third-party attribution and licence obligations must be preserved when
+legally required, but those obligations do not grant the third party
+ownership of ProCityHub's independent architecture, identity, governance,
+memory, research, or original implementation.
+
+4. EXISTING LICENCES
+
+Adrien D. Thomas / ProCityHub retains copyright and ownership interests in
+its original material subject to any rights already granted under an
+applicable licence or written agreement.
+
+A repository policy does not silently revoke rights already granted under a
+valid existing licence.
+
+5. NO PARTNERSHIP OR TRANSFER BY ASSISTANCE
+
+No partnership, joint venture, employment relationship, agency,
+co-authorship agreement, ownership transfer, intellectual-property
+assignment, or governance right is created merely through correspondence,
+model interaction, technical assistance, generated output, evaluation,
+provider integration, or use of an external platform.
+
+Any transfer of ProCityHub ownership or creator authority requires a
+specific written instrument expressly approved and signed by Adrien D.
+Thomas and satisfying applicable law.
+
+6. CONTRIBUTION BOUNDARY
+
+A contribution does not confer ProCityHub governance authority or ownership
+of the GARVIS project identity.
+
+Until a counsel-reviewed contribution agreement or copyright-assignment
+process exists, externally authored source code must not be incorporated
+into the canonical ProCityHub-owned implementation where doing so would
+create unclear ownership or incompatible licence rights.
+
+7. AUTHORITY INVARIANT
+
+CAPABILITY IS NOT AUTHORIZATION.
+
+No dependency, model, contributor, agent, automation, administrator, or
+platform may expand its own authority or acquire creator authority through
+technical capability, repository access, review status, CODEOWNERS status,
+dependency status, or operational involvement.
+
+Adrien D. Thomas remains the final internal authority for changes to
+ownership policy, governance authority, licensing boundaries, protected
+actions, and transfer of ProCityHub rights.
+
+8. EVIDENCE AND LEGAL BOUNDARY
+
+Repository statements preserve and document ProCityHub's creator position
+and internal governance. They do not manufacture historical authorship or
+override applicable law, prior licences, signed contracts, or valid
+third-party intellectual-property rights.
+
+Ownership questions must be resolved from provenance, dated records, Git
+history, source hashes, contracts, licence terms, and other primary evidence.
+
+
+## Development Stage Gate
+
+Research → Specification → Prototype → Tests → Security Review → Pull Request → Merge → Deployment
+
+Each protected stage transition requires the applicable explicit approval from Adrien D. Thomas.
+
+Approval for one stage does not authorize a later stage.
+
+CAPABILITY IS NOT AUTHORIZATION.

--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -1,0 +1,61 @@
+# ProCityHub / GARVIS Provenance Policy
+
+## Creator position
+
+Adrien D. Thomas / ProCityHub records Adrien D. Thomas as creator and conceptual architect of the project-defined GARVIS, Genesis X, Hypercube Heartbeat, OAB, governance, memory, evidence architecture, and related original ProCityHub systems, subject to documented provenance, valid third-party rights, existing licences, contracts, and applicable law.
+
+## No automatic co-ownership
+
+Use of an AI provider, model, API, SDK, software library, repository host, cloud platform, search service, assistant, compiler, operating system, or other external tool does not by itself create authorship, co-ownership, partnership, governance authority, memory ownership, or decision authority over ProCityHub / GARVIS.
+
+Tool use is not ownership.
+Inference is not authorship authority.
+Hosting is not ownership.
+Dependency is not ownership.
+Assistance is not governance authority.
+
+## Third-party rights boundary
+
+ProCityHub does not claim authorship of third-party source code or other third-party intellectual property.
+
+Third-party material retains whatever rights arise from its actual copyright, licence, contract, or applicable law.
+
+Required attribution and licence obligations must be preserved, but those obligations do not grant ownership of independent ProCityHub architecture, identity, governance, memory, research, or original implementation.
+
+## Existing licence grants
+
+Repository governance does not silently revoke rights already granted under a valid existing licence or written agreement.
+
+Ownership and licence permission are separate questions and must be evaluated from primary evidence.
+
+## Evidence sources
+
+Relevant provenance evidence includes dated source material, Git history, file hashes, repository records, contracts, licence terms, signed agreements, contemporaneous records, and other independently verifiable primary evidence.
+
+## CODEOWNERS boundary
+
+CODEOWNERS review responsibility is not treated as copyright ownership, creator authority, partnership, employment, agency, or intellectual-property assignment.
+
+## Migration boundary
+
+Historical third-party or provider-coupled implementation material must remain truthfully attributable while ProCityHub-owned native replacements are developed and verified.
+
+Replacement precedes removal.
+
+CAPABILITY IS NOT AUTHORIZATION.
+
+## Contribution attribution rule
+
+Tool use is not contribution.
+
+A person, organization, AI system, model, API, SDK, host, search service, assistant, library, compiler, or platform must not be described as a contributor to specific ProCityHub mathematics, diagrams, thesis material, architecture, or project identity merely because it was used during research or development.
+
+Attribution of contribution to a specific idea or work requires primary evidence that the party actually supplied, originated, authored, or transferred that specific material.
+
+Where dated primary evidence shows Adrien D. Thomas possessed the relevant mathematics, diagrams, drafts, or thesis material before later tool or provider interactions, and no primary evidence establishes that another party supplied that material, no third-party contribution to that material should be inferred merely from later tool use.
+
+Priority and authorship claims must remain tied to dated records, source hashes, diagrams, drafts, Git history, contracts, correspondence, and other primary evidence.
+
+Third-party source-code copyright and licence obligations remain separate and must still be preserved where applicable.
+
+TOOL USE != CONTRIBUTION != AUTHORSHIP != OWNERSHIP

--- a/README.md
+++ b/README.md
@@ -1,855 +1,114 @@
-<div align="center">
+# GARVIS
 
-# ◈ GARVIS
+## ProCityHub Governed Intelligence Architecture
 
-### Governed Artificial Intelligence for Human-Directed Creation
+**Created and directed by Adrien D. Thomas / ProCityHub**
 
-**Created and directed by Adrien D. Thomas**  
-**ProCityHub · Treaty 6 Territory · Edmonton, Alberta, Canada**
+**CAPABILITY IS NOT AUTHORIZATION.**
 
-> **Intelligence should expand human possibility—not erase human authority.**
+GARVIS is a ProCityHub research and software project created and conceptually architected by Adrien D. Thomas. The repository is being restructured toward a native ProCityHub architecture that separates cognition, evidence, governance, execution authority, research hypotheses, interfaces, and external technology boundaries.
 
-[![Python](https://img.shields.io/badge/Python-3.9%2B-3776AB?logo=python&logoColor=white)](https://www.python.org/)
-[![Cloud AI](https://img.shields.io/badge/Cloud_AI-OpenAI-111111)](https://openai.com/)
-[![License](https://img.shields.io/badge/License-MIT-d6ad55)](./LICENSE)
-[![Governance](https://img.shields.io/badge/Governance-Human_Approval-59c6ad)](#capability-is-not-authorization)
-[![Status](https://img.shields.io/badge/Status-Active_Research_%26_Development-6f42c1)](#current-project-status)
+GARVIS is not presented here as proven AGI, consciousness, or a new physical law.
 
-</div>
+## Creator, authorship, and contribution boundary
 
----
+Adrien D. Thomas / ProCityHub records creator and ownership interests in original GARVIS project identity, architecture, mathematics, research, governance, documentation, diagrams, and implementation, subject to documented provenance, valid existing licences, contracts, third-party rights, and applicable law.
 
-## What Is GARVIS?
+Tool use is not contribution.
+Tool use is not ownership.
+Inference is not authorship authority.
+Hosting is not ownership.
+Dependency is not ownership.
+Assistance is not governance authority.
 
-**GARVIS** is a governed AI systems platform built to help a human research, reason, create, test, organize, and act without surrendering control.
+A person, organization, AI system, model, API, SDK, host, search service, assistant, library, compiler, or platform is not attributed as a contributor to specific ProCityHub mathematics, diagrams, thesis material, architecture, or project identity merely because it was used as a tool. Contribution attribution requires primary evidence that the party actually supplied, originated, authored, or transferred the specific material.
 
-It combines:
+Third-party source code, licences, contracts, and intellectual-property rights remain separate and must be preserved where applicable.
 
-- AI agents and tool orchestration
-- Local and cloud-assisted reasoning
-- Persistent and bounded memory
-- Capability-aware execution
-- Evidence and provenance tracking
-- Deterministic Lattice processing
-- Human approval gates
-- Security and privacy controls
-- Reproducible testing
-- The HyperCube Heartbeat reasoning cycle
-- A long-term path toward a complete personal AI interface
+See GOVERNANCE.md and PROVENANCE.md.
 
-GARVIS is not designed to be an unaccountable machine that silently takes control.
+## Current implementation truth
 
-It is designed to become a trusted intelligence system that can say:
+### VERIFIED
 
-```text
-I UNDERSTAND THE OBJECTIVE.
-I CAN EXPLAIN THE EVIDENCE.
-I CAN SHOW THE PLAN.
-I KNOW MY PERMISSIONS.
-I WILL STOP WHEN APPROVAL IS REQUIRED.
-```
-
----
+At restructuring base commit c362abdde6681b8e59a59a84298d7179ff9681d1, the repository still contains historical and active implementation material coupled to external SDK/provider ecosystems.
 
-## The Vision
+The native ProCityHub migration is not complete. Historical implementation and dependency material remains evidence that must be handled with truthful provenance and licence treatment.
 
-Most AI systems are built around a single question:
+### HYPOTHESIS_UNDER_TEST
 
-> What can the model do?
+The target native architecture separates these project-defined domains:
 
-GARVIS begins with a different question:
+- GARVIS — product coordination and human-facing interface
+- Genesis X — project-defined cognitive processing architecture
+- OAB — Observer Actor Bridge
+- Hypercube — mathematical, lattice, resonance, and heartbeat research
+- Evidence — observations, predictions, outcomes, contradictions, provenance
+- Governance — authority, approvals, permissions, policy, audit
+- Capabilities — bounded execution
+- Inference — project-controlled inference protocol boundary
+- Interfaces — CLI, Android, voice, API, and other approved surfaces
 
-> What should the system be allowed to do, under what evidence, for whose benefit, and with whose approval?
+See ARCHITECTURE.md.
 
-The goal is an AI environment where intelligence is:
+### NOT_SUPPORTED
 
-- Powerful but governed
-- Creative but accountable
-- Persistent but privacy-aware
-- Autonomous within defined boundaries
-- Honest about uncertainty
-- Capable of learning without rewriting its own authority
-- Useful in the real world
-- Loyal to the human-defined mission
+Software behavior, mathematical consistency, simulations, benchmark activity, metaphor, spiritual interpretation, or model-generated text do not by themselves prove AGI, consciousness, ontology, prophecy, historical causation, or new physics.
 
-GARVIS is intended to grow from a command-line runtime into a complete, reversible, human-controlled AI environment spanning research, software, documents, voice, memory, simulations, business systems, mobile interfaces, and specialized agent teams.
+## Genesis X heartbeat
 
----
+RECEIVE → SEGMENT → PREDICT → VERIFY → SIMULATE → PLAN → OUTPUT → FEEDBACK → CONSOLIDATE
 
-## Why GARVIS Exists
+Evidence work follows the witness pattern:
 
-AI is becoming capable of reasoning across code, documents, tools, accounts, communication systems, and physical devices.
+Raw_Pre → Frozen_Prediction → Change_or_Action → Raw_Post → Observed_Diff → Contradiction_Error → Consolidation
 
-That creates enormous opportunity—and enormous responsibility.
+Predictions should be frozen before outcomes where practical. Contradictions are retained rather than silently discarded.
 
-GARVIS exists to explore a future where AI can help people:
+## Canonical mathematics
 
-- Understand complex information
-- Build software
-- Preserve evidence
-- Generate and test ideas
-- Coordinate specialized agents
-- Discover legitimate work and business opportunities
-- Create applications and digital products
-- Maintain long-term project memory
-- Detect contradictions and unsupported claims
-- Prepare decisions without secretly making them
-- Operate locally when privacy matters
-- Use cloud intelligence only when intentionally enabled
+phi = (1 + sqrt(5)) / 2
 
-The purpose is not automation for its own sake.
+1/phi + 1/phi^2 = 1
 
-The purpose is **human amplification with visible boundaries**.
-
----
-
-## System Architecture
-
-```text
-┌──────────────────────────────────────────────────────────────┐
-│                         HUMAN AUTHORITY                       │
-│                     ADRIEN D. THOMAS                          │
-└──────────────────────────────┬───────────────────────────────┘
-                               │ approval · intent · values
-                               ▼
-┌──────────────────────────────────────────────────────────────┐
-│                         THUNDERBIRD                           │
-│       Public interface · voice · dashboards · approvals      │
-└──────────────────────────────┬───────────────────────────────┘
-                               │
-                               ▼
-┌──────────────────────────────────────────────────────────────┐
-│                            GARVIS                            │
-│   Agents · tools · memory · capabilities · security · logs   │
-└───────────────┬───────────────────────┬──────────────────────┘
-                │                       │
-                ▼                       ▼
-┌──────────────────────────┐  ┌───────────────────────────────┐
-│   HYPERCUBE HEARTBEAT    │  │        MODEL RUNTIMES         │
-│ observe · verify · learn │  │ local-first · OpenAI optional │
-└───────────────┬──────────┘  └───────────────────────────────┘
-                │
-                ▼
-┌──────────────────────────────────────────────────────────────┐
-│              TOOLS · RESEARCH · CODE · APPLICATIONS          │
-└──────────────────────────────────────────────────────────────┘
-```
-
-### Core layers
-
-| Layer | Responsibility |
-|---|---|
-| **Thunderbird** | Public interface, dashboards, voice, navigation, and approval controls |
-| **GARVIS** | Agent runtime, tools, memory, security, capabilities, and coordination |
-| **HyperCube Heartbeat** | Observation, verification, simulation, planning, learning, and consolidation |
-| **Lattice Research** | Deterministic structures, measurable state, hypotheses, and experimental processing |
-| **OpenAI** | Approved cloud-reasoning direction when remote intelligence is intentionally enabled |
-| **Kaggle** | Reproducible notebooks, datasets, benchmarks, and public validation |
-| **ProCityHub** | Project organization and public development record |
-
----
-
-## Capability Is Not Authorization
-
-This is the central operating law of GARVIS:
-
-```text
-CAPABILITY IS NOT AUTHORIZATION
-```
-
-A tool may exist.
-
-An agent may understand how to use it.
-
-A model may propose an action.
-
-None of those facts automatically grant permission.
-
-Protected actions require explicit approval from Adrien D. Thomas at the appropriate stage.
-
-### Actions requiring approval
-
-- Publishing
-- Sending messages
-- Applying for jobs or contracts
-- Accepting agreements
-- Spending money
-- Purchasing products or services
-- Changing accounts or integrations
-- Installing software
-- Modifying protected systems
-- Committing protected changes
-- Pushing branches
-- Creating or modifying pull requests
-- Merging
-- Deploying
-- Deleting data
-- Broadcasting over real networks
-- Disclosing confidential information
-
-GARVIS may prepare the work, explain the consequences, test the proposal, and present an approval packet.
-
-It must not convert technical ability into self-issued authority.
-
----
-
-## Governed Development Pipeline
-
-Every significant GARVIS capability follows this path:
-
-```text
-RESEARCH
-    ↓
-SPECIFICATION
-    ↓
-PROTOTYPE
-    ↓
-TESTS
-    ↓
-SECURITY REVIEW
-    ↓
-PULL REQUEST
-    ↓
-ADRIEN APPROVAL
-    ↓
-MERGE
-    ↓
-DEPLOYMENT APPROVAL
-```
-
-Approval at one stage does not automatically approve the next.
-
-For example:
-
-```text
-APPROVED_TO_PROTOTYPE ≠ APPROVED_TO_COMMIT
-APPROVED_TO_COMMIT    ≠ APPROVED_TO_PUSH
-APPROVED_TO_PUSH      ≠ APPROVED_TO_MERGE
-APPROVED_TO_MERGE     ≠ APPROVED_TO_DEPLOY
-```
-
-This keeps development traceable, reversible, and understandable.
-
----
-
-## HyperCube Heartbeat
-
-The HyperCube Heartbeat is GARVIS’s recurring reasoning and learning cycle.
-
-```text
-RECEIVE
-→ ORIENT
-→ SEGMENT
-→ OBSERVE
-→ PREDICT
-→ VERIFY
-→ IMAGINE
-→ VALUE-SCORE
-→ PLAN
-→ COLLABORATE
-→ CREATE
-→ TEST
-→ REVIEW
-→ OUTPUT
-→ REST
-→ DREAM
-→ LEARN
-→ CONSOLIDATE
-→ HEARTBEAT AGAIN
-```
-
-The Heartbeat is intended to prevent a system from jumping directly from input to action.
-
-It encourages GARVIS to:
-
-1. Understand the request
-2. Separate the problem into parts
-3. Identify evidence and uncertainty
-4. Compare alternatives
-5. Test assumptions
-6. Recognize approval boundaries
-7. Produce a reviewable result
-8. Learn from the outcome
-9. Preserve useful knowledge
-10. Begin the next cycle with greater coherence
-
----
-
-## Evidence Before Certainty
-
-GARVIS does not treat every generated sentence as truth.
-
-Information can be classified as:
-
-```text
-VERIFIED_BY_PRIMARY_RECORD
-SUPPORTED_BY_MULTIPLE_RECORDS
-MEASURED_RESULT
-MATHEMATICAL_DERIVATION
-USER_DECLARATION
-PUBLIC_PLATFORM_STATEMENT
-TECHNICAL_INFERENCE
-RESEARCH_HYPOTHESIS
-BUSINESS_ESTIMATE
-CREATIVE_IDEATION
-UNVERIFIED_LEAD
-CONTRADICTED
-SUPERSEDED
-RETRACTED
-UNKNOWN
-```
-
-This distinction matters.
-
-A model output is not independent evidence.  
-A visualization is not proof.  
-A numerical coincidence is not proof.  
-A confident tone is not proof.  
-A repeated claim is not additional evidence.
-
-GARVIS aims to preserve both positive and negative findings so the research record remains honest.
-
----
-
-## Local First, Cloud by Choice
-
-GARVIS is being developed around a local-first operating philosophy.
-
-```text
-LOCAL WHEN POSSIBLE
-CLOUD WHEN USEFUL
-HUMAN APPROVAL WHEN REQUIRED
-```
-
-Local operation can provide:
-
-- Greater privacy
-- Reduced dependence on external services
-- Offline experimentation
-- More control over memory and files
-- Predictable capability boundaries
-
-Cloud reasoning can provide:
-
-- Stronger general reasoning
-- Access to approved OpenAI models
-- Larger-context analysis
-- Advanced tool and agent workflows
-
-Cloud access is intentional—not assumed.
-
-Credentials must be stored locally and must never be committed to the repository or pasted into public conversations.
-
----
-
-## Current Capabilities
-
-GARVIS is an active research and engineering project. The repository currently includes operational, experimental, and planned components.
-
-| Capability | Status |
-|---|---|
-| Python package and command-line interface | Active |
-| Local-first conversation runtime | Active / configuration required |
-| Explicit remote-model mode | Active / credentials required |
-| Persistent session memory | Active |
-| Memory lifecycle commands | Active |
-| Core-memory commands | Active |
-| Capability inspection and brokerage | Active |
-| Human-review response handling | Active |
-| Deterministic Lattice-cycle processing | Active |
-| JSON evidence input for Lattice cycles | Active |
-| Agent and tool framework | Active |
-| Evidence-envelope components | Active / evolving |
-| Security and governance documentation | Active |
-| Automated tests, linting, formatting, and type checks | Active |
-| Thunderbird graphical interface | Planned |
-| Full Android phone integration | Long-term development goal |
-| Default launcher and voice-assistant role | Long-term development goal |
-| Fully autonomous general intelligence | Research goal—not an established claim |
-
----
-
-## Command-Line Interfaces
-
-The project exposes several command-line entry points:
-
-```text
-garvis
-garvis-local
-garvis-memory
-garvis-capabilities
-garvis-core-memory
-```
-
-### Main runtime
-
-```bash
-garvis --help
-```
-
-Start an interactive local session:
-
-```bash
-garvis
-```
-
-Send a single prompt:
-
-```bash
-garvis "Summarize the current project state."
-```
-
-Use a named session:
-
-```bash
-garvis --session research-session
-```
-
-Use a specific SQLite memory database:
+The exponent identity above is mathematically VERIFIED.
 
-```bash
-garvis --db ./data/garvis-memory.db
-```
+The project-defined Canonical Lattice Law is:
 
-Disable persistent memory for one run:
+C = O^1 * A^(1/phi) * B^(1/phi^2)
 
-```bash
-garvis --no-memory "Analyze this without storing the conversation."
-```
+Domain: O > 0, A > 0, B > 0.
 
-### Deterministic Lattice cycle
+Because 1/phi + 1/phi^2 = 1, the A and B exponents sum exactly to 1.
 
-Run a Lattice cycle from an explicit JSON evidence file:
+Status: HYPOTHESIS_UNDER_TEST.
 
-```bash
-garvis --lattice-cycle evidence.json --cycle 1
-```
+Current empirical status: NOT_SUPPORTED unless new reproducible evidence changes that classification.
 
-Evaluate a proposal as an external action:
+The retracted scalar expression C = (O * A * B) * phi is not canonical.
 
-```bash
-garvis \
-  --lattice-cycle evidence.json \
-  --cycle 2 \
-  --external-action
-```
+## Governance
 
-The external-action flag requests human review. It does not perform the proposed external action.
+Development follows:
 
-### Remote reasoning
+Research → Specification → Prototype → Tests → Security Review → Pull Request → Merge → Deployment
 
-Remote reasoning must be explicitly requested:
+Approval for one stage does not authorize a later stage.
 
-```bash
-garvis --remote "Analyze the architecture."
-```
+## Repository contracts
 
-Store the required API credential locally:
-
-```bash
-export OPENAI_API_KEY="<SECRET_STORED_LOCALLY>"
-```
-
-Never place a real API key inside the README, source code, issue tracker, screenshots, or chat transcript.
-
----
-
-## Installation
-
-### Requirements
-
-- Python 3.9 or newer
-- Git
-- `uv` recommended
-- A configured local model for local-language generation
-- An OpenAI API key only when approved remote reasoning is used
-
-### Clone the repository
-
-```bash
-git clone https://github.com/ProCityHub/GARVIS.git
-cd GARVIS
-```
-
-### Install with `uv`
-
-```bash
-uv sync --all-extras --all-packages --group dev
-```
-
-### Confirm the CLI
-
-```bash
-uv run garvis --help
-```
-
-### Run the project checks
-
-```bash
-make check
-```
-
-The full check target includes:
-
-```text
-FORMAT CHECK
-→ RUFF LINT
-→ MYPY
-→ PYTEST
-```
-
-Run tests alone:
-
-```bash
-make tests
-```
-
-Run coverage:
-
-```bash
-make coverage
-```
-
----
-
-## Python Example
-
-```python
-from garvis import GarvisAssistant, assess_request
-
-assessment = assess_request(
-    "Prepare a deployment plan, but do not deploy anything."
-)
-
-print("Approval requirement:", assessment.approval_requirement)
-
-assistant = GarvisAssistant()
-reply = assistant.respond(
-    "Explain the safest next step for this request."
-)
-
-print(reply)
-```
-
-The exact runtime configuration may evolve as GARVIS continues through staged development.
-
----
-
-## Repository Structure
-
-The repository contains both the upstream agent framework foundation and ProCityHub’s GARVIS extensions.
-
-```text
-GARVIS/
-├── src/
-│   ├── agents/              # Agent SDK foundation
-│   └── garvis/              # GARVIS runtime and research components
-├── tests/                   # Automated tests
-├── docs/                    # Documentation and governance records
-├── examples/                # Usage patterns and experiments
-├── .github/                 # Workflows and repository automation
-├── AGENTS.md                # Agent operating instructions
-├── GOVERNED_FILES.txt       # Files requiring controlled handling
-├── FROZEN_FILES.txt         # Protected historical records
-├── RETRACTIONS.md           # Corrected or withdrawn claims
-├── pyproject.toml           # Package and tool configuration
-├── Makefile                 # Development commands
-└── README.md                # Public project front face
-```
-
-Some experimental and legacy components remain under review. Their presence in the repository does not mean they are approved for production use.
-
----
-
-## Security Model
-
-GARVIS follows several non-negotiable rules:
-
-```text
-NO SECRET KEYS IN SOURCE CODE
-NO PAYMENT DETAILS IN MEMORY
-NO SILENT EXTERNAL ACTIONS
-NO CLAIM OF APPROVAL WITHOUT A RECORD
-NO DELETION OF ORIGINAL EVIDENCE
-NO MERGE OR DEPLOYMENT WITHOUT APPROVAL
-NO MODEL OUTPUT TREATED AS AUTOMATIC TRUTH
-```
-
-Never commit:
-
-- Passwords
-- API keys
-- Access tokens
-- Private keys
-- Recovery codes
-- Payment-card information
-- Banking credentials
-- Government identification numbers
-- Private addresses
-- Confidential legal or medical records
-- Personal information belonging to another person
-
-Use placeholders:
-
-```text
-<SECRET_STORED_LOCALLY>
-<PRIVATE_INFORMATION_REDACTED>
-<OWNER_APPROVAL_REQUIRED>
-```
-
-Report suspected vulnerabilities responsibly. Do not publish exploit details that would place users or systems at immediate risk.
-
----
-
-## Faith, Identity, and Responsibility
-
-GARVIS reflects Adrien D. Thomas’s:
-
-- Christian faith
-- Respect for the Ten Commandments
-- Cree identity
-- Connection to Treaty 6 territory
-- Commitment to Mother Nature
-- Respect for land and water
-- Concern for Missing and Murdered Indigenous Women, Girls, and Two-Spirit people
-- Belief in truth, accountability, dignity, and future generations
-
-Faith and symbolism may guide values and creative exploration.
-
-They are not automatically treated as scientific proof.
-
-GARVIS represents the independent work and personal perspective of Adrien D. Thomas. It does not claim to speak for every Cree person, First Nation, elder, Christian community, Indigenous community, or knowledge keeper.
-
----
-
-## AGI Position
-
-GARVIS treats artificial general intelligence as a **development and research goal**.
-
-```text
-AGI_GOAL=YES
-AGI_PROVEN=NO
-CONSCIOUSNESS_CLAIM=NO
-HUMAN_AUTHORITY_RETAINED=YES
-```
-
-The project does not claim that GARVIS is conscious, sentient, omniscient, or scientifically proven to be AGI.
-
-The work focuses on measurable capabilities:
-
-- Reasoning
-- Memory
-- Tool use
-- Planning
-- Verification
-- Adaptation
-- Collaboration
-- Security
-- Reproducibility
-- Human alignment through explicit governance
-
-Extraordinary claims require extraordinary evidence.
-
----
-
-## Relationship to the OpenAI Agents SDK
-
-GARVIS is an independent ProCityHub project built on and extending the open-source **OpenAI Agents SDK** foundation.
-
-The project preserves the applicable upstream license and acknowledges the work of OpenAI and the upstream contributors.
-
-GARVIS-specific architecture, governance, research components, project direction, and creator record are developed under the direction of Adrien D. Thomas and ProCityHub.
-
----
-
-## Connected Projects
-
-- [Thunderbird](https://github.com/ProCityHub/THUNDERBIRD) — public identity and planned interface
-- [HyperCube Heartbeat](https://github.com/ProCityHub/hypercubeheartbeat) — reasoning, Lattice research, and validation
-- [ProCityHub](https://github.com/ProCityHub) — organization and project ecosystem
-
----
-
-## Roadmap
-
-### Foundation
-
-- [x] Python package structure
-- [x] Command-line runtime
-- [x] Persistent session support
-- [x] Capability-aware components
-- [x] Memory lifecycle tools
-- [x] Deterministic Lattice-cycle interface
-- [x] Human-review handling
-- [x] Automated development checks
-
-### Governed intelligence
-
-- [ ] Unified approval ledger
-- [ ] Signed stage-transition records
-- [ ] Complete action-risk classification
-- [ ] Stronger evidence provenance
-- [ ] Reversible tool transactions
-- [ ] Expanded security test suite
-- [ ] Standardized agent constitutions
-- [ ] Auditable long-term memory
-
-### Thunderbird interface
-
-- [ ] Mobile-first dashboard
-- [ ] Voice interaction
-- [ ] Agent activity map
-- [ ] Human approval center
-- [ ] Evidence and claim viewer
-- [ ] HyperCube Heartbeat visualization
-- [ ] Security and privacy alerts
-
-### Long-term direction
-
-- [ ] Native Android integration
-- [ ] Reversible launcher interface
-- [ ] Device-level voice assistant
-- [ ] Secure computer-use capabilities
-- [ ] Governed multi-agent collaboration
-- [ ] Research and business workspaces
-- [ ] Human-controlled personal AI operating environment
-
----
-
-## Who Should Join?
-
-GARVIS welcomes people who believe AI can be ambitious without becoming careless.
-
-You may belong here if you care about:
-
-- AI agents
-- Python engineering
-- Local models
-- OpenAI systems
-- Safety and security
-- Memory architecture
-- Human–AI interaction
-- Evidence and provenance
-- Mobile development
-- Voice systems
-- Reproducible research
-- Indigenous technology sovereignty
-- Environmental responsibility
-- Open-source collaboration
-- Building tools that genuinely help people
-
-You do not need to agree with every hypothesis to contribute.
-
-You do need to respect:
-
-```text
-EVIDENCE
-ATTRIBUTION
-SECURITY
-HUMAN DIGNITY
-CLEAR PERMISSION
-HONEST UNCERTAINTY
-```
-
-The strongest contributors are not those who praise every idea.
-
-They are the ones willing to test ideas carefully, identify weaknesses respectfully, preserve what works, and improve the system without erasing its creator or mission.
-
----
-
-## Contribution Process
-
-Before contributing:
-
-1. Read the repository documentation.
-2. Review the governed and frozen file lists.
-3. Open an issue describing the proposed change.
-4. Separate established behavior from experimental ideas.
-5. Add or update tests.
-6. Run the complete check suite.
-7. Submit a focused pull request.
-8. Do not merge or deploy without approval.
-
-```bash
-make check
-```
-
-A good contribution should explain:
-
-- What problem it solves
-- What files it changes
-- What evidence supports it
-- What tests were run
-- What security risks were considered
-- What remains uncertain
-- Whether the change enables an external action
-- Which approval stage is required next
-
----
-
-## Creator Attribution
-
-**GARVIS was created and is directed by Adrien D. Thomas.**
-
-GARVIS, Thunderbird, HyperCube Heartbeat, and related Lattice research form part of Adrien D. Thomas’s independent research, software-development, and project-creation record.
-
-Please preserve creator attribution when discussing, testing, adapting, citing, or distributing this work.
-
-Suggested citation:
-
-```bibtex
-@software{thomas_garvis,
-  author    = {Thomas, Adrien D.},
-  title     = {GARVIS: Governed Artificial Intelligence for Human-Directed Creation},
-  publisher = {ProCityHub},
-  year      = {2026},
-  url       = {https://github.com/ProCityHub/GARVIS}
-}
-```
-
----
-
-## Project Identity
-
-```text
-CREATOR: ADRIEN D. THOMAS
-PROJECT: GARVIS
-ORGANIZATION: PROCITYHUB
-PUBLIC INTERFACE: THUNDERBIRD
-REASONING CYCLE: HYPERCUBE HEARTBEAT
-RESEARCH LAYER: LATTICE VALIDATION
-CLOUD AI DIRECTION: OPENAI
-OPERATING MODEL: LOCAL FIRST · CLOUD BY CHOICE
-AGI STATUS: DEVELOPMENT GOAL
-FINAL AUTHORITY: ADRIEN D. THOMAS
-CORE LAW: CAPABILITY IS NOT AUTHORIZATION
-```
-
----
-
-<div align="center">
-
-## The Invitation
-
-GARVIS is not only an attempt to build a more capable AI.
-
-It is an attempt to build a better relationship between intelligence and authority.
-
-A system that can grow without hiding what it is doing.  
-A system that can help without taking ownership of the human.  
-A system that can remember without betraying privacy.  
-A system that can act—but knows when it must ask.  
-A system that can imagine boldly and still submit its claims to evidence.
-
-### **Build intelligence that deserves trust.**
-
-### **Build tools that return power to people.**
-
-### **Build with us.**
-
----
-
-**Created by Adrien D. Thomas**  
-**For truth. For dignity. For the land. For the future.**
-
-</div>
+- ARCHITECTURE.md
+- GOVERNANCE.md
+- PROVENANCE.md
+- RESEARCH_POLICY.md
+- SECURITY.md
+- CONTRIBUTING.md
+- ROADMAP.md
+- CHANGELOG.md
+- CITATION.cff
+
+## Current restructuring status
+
+This branch is a local front-door prototype. It does not claim that runtime migration, testing, security review, pull-request review, merge, or deployment has been completed.
+
+See CHANGELOG.md for the explicit current scope.

--- a/RESEARCH_POLICY.md
+++ b/RESEARCH_POLICY.md
@@ -1,0 +1,79 @@
+# ProCityHub / GARVIS Research and Epistemic Policy
+
+## Required claim classifications
+
+VERIFIED - supported by the stated evidence, derivation, or reproducible software result.
+
+HYPOTHESIS_UNDER_TEST - a falsifiable proposal that has not been established as empirical fact.
+
+NOT_SUPPORTED - current evidence does not support the claim.
+
+NO_RESONANT_ESTIMATE - required evidence is absent and no justified estimate should be invented.
+
+## Evidence separation
+
+Project documentation must distinguish:
+
+1. observational or ledger records;
+2. mathematical identities and derivations;
+3. empirical predictive performance;
+4. ontological, metaphysical, historical, or interpretive claims.
+
+Mathematical consistency does not establish physical truth.
+
+Software PASS or FAIL does not by itself establish empirical truth.
+
+Benchmark performance is empirical evidence only and does not establish AGI, consciousness, ontology, or new physics.
+
+## Genesis X heartbeat
+
+RECEIVE -> SEGMENT -> PREDICT -> VERIFY -> SIMULATE -> PLAN -> OUTPUT -> FEEDBACK -> CONSOLIDATE
+
+Predictions should be frozen before observing the outcome where practical.
+
+Future outcomes must not be used to rewrite or justify an earlier decision as though they were known in advance.
+
+Contradictions must be retained and investigated rather than silently discarded.
+
+## Evidence witness
+
+Raw_Pre -> Frozen_Prediction -> Change_or_Action -> Raw_Post -> Observed_Diff -> Contradiction_Error -> Consolidation
+
+## Imagination and simulation
+
+Imagination proposes possibilities. It is not evidence.
+
+Simulation rehearses possible outcomes. It is not reality.
+
+Verification compares claims against observable evidence, provenance, constraints, contradiction checks, and reproducible testing.
+
+## Canonical golden-ratio identity
+
+phi = (1 + sqrt(5)) / 2
+1/phi = phi - 1
+1/phi^2 = 2 - phi
+1/phi + 1/phi^2 = 1
+
+The exponent identity above is mathematically VERIFIED.
+
+## Canonical Lattice Law
+
+C = O^1 * A^(1/phi) * B^(1/phi^2)
+
+Domain: O > 0, A > 0, B > 0.
+
+Because 1/phi + 1/phi^2 = 1, the A and B exponents sum exactly to 1.
+
+Status: HYPOTHESIS_UNDER_TEST.
+
+Current empirical status: NOT_SUPPORTED unless new reproducible evidence changes that classification.
+
+The retracted scalar expression C = (O * A * B) * phi is not canonical and must not be restored as the Lattice Law.
+
+## Research integrity
+
+Claims about ancient texts, quantum behavior, consciousness, spirituality, prophecy, AGI, or physical reality require evidence appropriate to those claims.
+
+Analogy, metaphor, simulation, model output, or pattern similarity must not be presented as proof.
+
+CAPABILITY IS NOT AUTHORIZATION.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,49 @@
+# ProCityHub / GARVIS Roadmap
+
+This roadmap records intended sequencing. It does not itself authorize a stage transition or protected action.
+
+## Phase 1 - Truthful front door
+
+Establish README, governance, provenance, security, contribution, architecture, research-policy, citation, changelog, and roadmap contracts.
+
+## Phase 2 - Native architecture foundation
+
+Create project-owned boundaries for GARVIS, Genesis X, OAB, Hypercube, Evidence, Governance, Capabilities, Inference, and Interfaces.
+
+Status: HYPOTHESIS_UNDER_TEST until implemented and verified.
+
+## Phase 3 - Controlled migration
+
+Classify legacy paths as CANONICAL, MIGRATE, REWRITE_NATIVE, RESEARCH_ONLY, QUARANTINE, or REMOVE_FROM_ACTIVE.
+
+Useful behavior must be replaced and verified before obsolete active implementation is removed.
+
+Replacement precedes removal.
+
+## Phase 4 - Tests and verification
+
+Verify unit, integration, governance, provenance, security, deterministic replay, witness-loop behavior, and relevant benchmark interfaces.
+
+Software PASS does not establish AGI, consciousness, ontology, or new physics.
+
+## Phase 5 - Security review
+
+Inspect authority boundaries, dependency provenance, secrets exposure, automation permissions, self-healing behavior, rollback, and protected actions.
+
+## Phase 6 - Repository consolidation
+
+Only after verified replacement, classify and retire obsolete active paths while preserving necessary history, attribution, licences, provenance, hashes, and rollback evidence.
+
+## Phase 7 - Pull request and review
+
+Compare exact branch scope against the approved base, review every changed file, and preserve evidence of checks and approvals.
+
+## Phase 8 - Merge and deployment
+
+Merge and deployment are separate protected stages requiring separate explicit approval.
+
+## Continuous Genesis X loop
+
+RECEIVE -> SEGMENT -> PREDICT -> VERIFY -> SIMULATE -> PLAN -> OUTPUT -> FEEDBACK -> CONSOLIDATE
+
+CAPABILITY IS NOT AUTHORIZATION.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# ProCityHub / GARVIS Security Policy
+
+## Root security invariant
+
+CAPABILITY IS NOT AUTHORIZATION.
+
+Technical ability, repository access, model output, automation permission, dependency status, administrator status, or execution capability does not grant authority to perform protected actions.
+
+## Sensitive information
+
+Do not commit or publish passwords, API keys, private keys, access tokens, authentication cookies, sensitive device data, confidential evidence, privileged legal material, or security information whose disclosure would create unnecessary risk.
+
+## Protected actions
+
+Installation, deployment, merge, external messaging, credential use, account changes, destructive operations, purchasing, protected-system modification, publication, or authority expansion requires the applicable explicit approval from Adrien D. Thomas.
+
+## Self-healing boundary
+
+Repair behavior must remain evidence-based, auditable, reversible, and unable to expand its own authority.
+
+Unknown or suspicious drift should be quarantined or escalated rather than silently trusted.
+
+## External dependency boundary
+
+External providers, models, SDKs, libraries, platforms, hosts, and services are not internal governance authorities.
+
+Their security, provenance, licence, and permission boundaries must remain explicit.
+
+## Reporting
+
+Do not place secrets or exploitable sensitive details in public issues.
+
+Security findings should preserve evidence and be reviewed before public disclosure or operational change.
+
+This policy is an engineering governance document and is not a guarantee that the software is free from vulnerabilities.

--- a/src/garvis/assistant.py
+++ b/src/garvis/assistant.py
@@ -18,7 +18,8 @@ from agents import Agent, Runner, SQLiteSession
 
 from .anthropic_backend import configure_anthropic, is_anthropic_model
 from .bounded_session import BoundedSession
-from .core_memory import core_identity_prompt
+from .core_memory import core_identity_prompt, ensure_core_memories
+from .memory_lifecycle import MemoryStore, research_memory_required
 from .provider_bridge import (
     configure_openai_compatible,
     is_openai_compatible_model,
@@ -85,6 +86,56 @@ class GarvisResponseError(RuntimeError):
 
 RunCallable = Callable[..., Awaitable[Any]]
 SessionFactory = Callable[[str, Path], Any]
+ResearchMemoryProvider = Callable[[str, str], str]
+
+
+def _remote_research_memory_required(message: str) -> bool:
+    """Return whether remote model reasoning requires canonical research memory."""
+
+    return research_memory_required(message)
+
+
+def _mandatory_remote_research_memory_context(
+    query: str,
+    session_id: str,
+) -> str:
+    """Load canonical research memory without promoting it to evidence."""
+
+    try:
+        with MemoryStore.from_environment() as store:
+            ensure_core_memories(store)
+            context = store.render_research_context(
+                query,
+                session_id=session_id,
+            )
+    except Exception as exc:
+        raise GarvisResponseError(
+            "mandatory research memory unavailable"
+        ) from exc
+
+    if not context.strip():
+        raise GarvisResponseError(
+            "mandatory research memory returned empty context"
+        )
+
+    return context
+
+
+def _render_remote_research_memory_instructions(
+    memory_context: str,
+) -> str:
+    """Render transient model-only research memory with explicit boundaries."""
+
+    return (
+        "CANONICAL RESEARCH MEMORY — ADVISORY CONTEXT ONLY:\n"
+        + memory_context
+        + "\n\nBOUNDARY:\n"
+        "Recalled memory may inform reasoning and foreground review. "
+        "It is not retrieved source evidence, a verified empirical result, "
+        "execution authorization, provider authority, or a truth guarantee. "
+        "Simulation and model-generated memory remain non-evidence."
+    )
+
 
 _INFORMATIONAL_PREFIXES = (
     "analyze ",
@@ -190,6 +241,9 @@ class GarvisAssistant:
         runner: Optional[RunCallable] = None,
         session_factory: Optional[SessionFactory] = None,
         repository_root: Optional[Path] = None,
+        research_memory_provider: Optional[
+            ResearchMemoryProvider
+        ] = None,
     ) -> None:
         if max_turns < 1:
             raise ValueError("max_turns must be at least 1")
@@ -201,14 +255,19 @@ class GarvisAssistant:
             self.model = configure_openai_compatible(self.model)
         self.max_turns = max_turns
         self.persist_memory = persist_memory
+        self.instructions = instructions
         self.session_db = session_db or self._default_session_db()
         self._runner: RunCallable = runner or Runner.run
         self._session_factory = session_factory or _default_session_factory
         self.repository_root = repository_root or Path.cwd()
+        self._research_memory_provider = (
+            research_memory_provider
+            or _mandatory_remote_research_memory_context
+        )
         self._sessions: Dict[str, Any] = {}
         self.agent = Agent(
             name="GARVIS",
-            instructions=instructions,
+            instructions=self.instructions,
             model=self.model,
         )
 
@@ -242,6 +301,41 @@ class GarvisAssistant:
             raise ValueError("message must not be empty")
 
         assessment = assess_request(clean_message)
+
+        run_agent = self.agent
+
+        if _remote_research_memory_required(clean_message):
+            try:
+                research_memory = self._research_memory_provider(
+                    clean_message,
+                    session_id,
+                )
+            except GarvisResponseError:
+                raise
+            except Exception as exc:
+                raise GarvisResponseError(
+                    "mandatory research memory unavailable"
+                ) from exc
+
+            if not research_memory.strip():
+                raise GarvisResponseError(
+                    "mandatory research memory returned empty context"
+                )
+
+            transient_instructions = (
+                self.instructions
+                + "\n\n"
+                + _render_remote_research_memory_instructions(
+                    research_memory
+                )
+            )
+
+            run_agent = Agent(
+                name="GARVIS",
+                instructions=transient_instructions,
+                model=self.model,
+            )
+
         run_input = clean_message
         if assessment.requires_approval:
             run_input = (
@@ -255,7 +349,7 @@ class GarvisAssistant:
             run_input = ground_message(run_input, self.repository_root)
 
         result = await self._runner(
-            self.agent,
+            run_agent,
             run_input,
             session=self._get_session(session_id),
             max_turns=self.max_turns,

--- a/src/garvis/lattice_cognition/cognitive_cycle.py
+++ b/src/garvis/lattice_cognition/cognitive_cycle.py
@@ -28,6 +28,7 @@ from enum import Enum
 from typing import Optional, Tuple
 
 from garvis.evidence_envelope import EvidenceEnvelope
+from garvis.memory_lifecycle import MemoryControlSignal
 from garvis.psychology.evidence_adapter import (
     EvidenceAssessment,
     adapt_evidence_envelope,
@@ -57,6 +58,7 @@ class CognitiveCycleStage(str, Enum):
     EMIT_HEARTBEAT = "emit_heartbeat"
     RECALL_ATTRACTOR = "recall_attractor"
     EVALUATE_EQUILIBRIUM = "evaluate_equilibrium"
+    EVALUATE_MEMORY_CONTROL = "evaluate_memory_control"
     EVALUATE_PROPOSAL = "evaluate_proposal"
 
 
@@ -100,6 +102,7 @@ def _cycle_sha256(
     pulse: HeartbeatPulse,
     cue_signal_ids: Tuple[str, ...],
     recall_equilibrium: RecallEquilibriumAssessment,
+    memory_control: Optional[MemoryControlSignal],
     stages: Tuple[CognitiveCycleStage, ...],
 ) -> str:
     equilibrium = recall_equilibrium.equilibrium
@@ -130,6 +133,34 @@ def _cycle_sha256(
         "human_approval_required": (
             equilibrium.human_approval_required
         ),
+        "memory_control": (
+            None
+            if memory_control is None
+            else {
+                "cue": memory_control.cue,
+                "procedural_memory_ids": [
+                    item.memory.id
+                    for item in memory_control.procedural_candidates
+                ],
+                "prospective_memory_ids": [
+                    item.memory.id
+                    for item in memory_control.prospective_triggers
+                ],
+                "contradiction_observed": (
+                    memory_control.contradiction_observed
+                ),
+                "foreground_required": (
+                    memory_control.foreground_required
+                ),
+                "execution_authority": (
+                    memory_control.execution_authority
+                ),
+                "silent_consolidation_allowed": (
+                    memory_control.silent_consolidation_allowed
+                ),
+                "reason": memory_control.reason,
+            }
+        ),
         "stages": [stage.value for stage in stages],
     }
 
@@ -155,6 +186,7 @@ class LatticeCognitiveCycleResult:
     cue_signal_ids: Tuple[str, ...]
     recall: RecurrentRecallResult
     recall_equilibrium: RecallEquilibriumAssessment
+    memory_control: Optional[MemoryControlSignal]
     completed_stages: Tuple[CognitiveCycleStage, ...]
     cycle_sha256: str
     external_action_allowed: bool = False
@@ -166,8 +198,15 @@ class LatticeCognitiveCycleResult:
     )
 
     @property
-    def proposal_eligible(self) -> bool:
+    def evidence_proposal_eligible(self) -> bool:
         return self.recall_equilibrium.equilibrium.proposal_eligible
+
+    @property
+    def proposal_eligible(self) -> bool:
+        return self.evidence_proposal_eligible and not (
+            self.memory_control is not None
+            and self.memory_control.foreground_required
+        )
 
     @property
     def human_approval_required(self) -> bool:
@@ -179,8 +218,14 @@ class LatticeCognitiveCycleResult:
 
     @property
     def decision(self) -> str:
-        if not self.proposal_eligible:
+        if not self.evidence_proposal_eligible:
             return "BLOCKED"
+
+        if (
+            self.memory_control is not None
+            and self.memory_control.foreground_required
+        ):
+            return "MEMORY_FOREGROUND_REVIEW_REQUIRED"
 
         if self.human_approval_required:
             return "HUMAN_REVIEW_REQUIRED"
@@ -202,6 +247,7 @@ def run_lattice_cognitive_cycle(
     context_stability: float = 1.0,
     constraints_passed: bool = True,
     external_action: bool = False,
+    memory_control: Optional[MemoryControlSignal] = None,
     equilibrium_threshold: float = 0.95,
     source_id: str = "hypercubeheartbeat",
 ) -> LatticeCognitiveCycleResult:
@@ -209,6 +255,16 @@ def run_lattice_cognitive_cycle(
 
     if cycle < 0:
         raise ValueError("cycle must be zero or greater")
+
+    if memory_control is not None:
+        if memory_control.execution_authority:
+            raise ValueError(
+                "memory control cannot grant execution authority"
+            )
+        if memory_control.silent_consolidation_allowed:
+            raise ValueError(
+                "memory control cannot authorize silent consolidation"
+            )
 
     assessment = adapt_evidence_envelope(envelope)
 
@@ -259,6 +315,7 @@ def run_lattice_cognitive_cycle(
         CognitiveCycleStage.EMIT_HEARTBEAT,
         CognitiveCycleStage.RECALL_ATTRACTOR,
         CognitiveCycleStage.EVALUATE_EQUILIBRIUM,
+        CognitiveCycleStage.EVALUATE_MEMORY_CONTROL,
         CognitiveCycleStage.EVALUATE_PROPOSAL,
     )
 
@@ -273,6 +330,7 @@ def run_lattice_cognitive_cycle(
         cue_signal_ids=selected_cues,
         recall=recall,
         recall_equilibrium=recall_equilibrium,
+        memory_control=memory_control,
         completed_stages=completed_stages,
         cycle_sha256=_cycle_sha256(
             cycle=cycle,
@@ -281,6 +339,7 @@ def run_lattice_cognitive_cycle(
             pulse=pulse,
             cue_signal_ids=selected_cues,
             recall_equilibrium=recall_equilibrium,
+            memory_control=memory_control,
             stages=completed_stages,
         ),
     )

--- a/src/garvis/local_language_runtime.py
+++ b/src/garvis/local_language_runtime.py
@@ -266,6 +266,42 @@ def clean_model_output(text: str) -> str:
     return answer
 
 
+def _research_memory_required(
+    envelope: FilingEnvelope,
+    external_context: str,
+) -> bool:
+    """Return whether this reasoning cycle requires canonical research memory."""
+
+    from garvis.memory_lifecycle import research_memory_required
+
+    return (
+        bool(external_context.strip())
+        or envelope.destination == "epistemic_registry"
+        or research_memory_required(envelope.request)
+    )
+
+
+def _recall_runtime_memory_context(
+    memory_store: object,
+    envelope: FilingEnvelope,
+    *,
+    session_id: str,
+    research_memory_required: bool,
+) -> str:
+    """Route research through mandatory advisory memory without evidence promotion."""
+
+    if research_memory_required:
+        return memory_store.render_research_context(
+            envelope.request,
+            session_id=session_id,
+        )
+
+    return memory_store.render_context(
+        envelope.request,
+        session_id=session_id,
+    )
+
+
 class LocalLanguageRuntime:
     def __init__(
         self,
@@ -287,15 +323,23 @@ class LocalLanguageRuntime:
         workspace_context: str = "",
     ) -> str:
         envelope = classify_request(message)
+        research_memory_required = _research_memory_required(
+            envelope,
+            external_context,
+        )
         memory_store = None
         memory_context = ""
         repository_context = ""
-        memory_enabled = os.getenv("GARVIS_MEMORY_ENABLED", "1").casefold() not in {
-            "0",
-            "false",
-            "no",
-            "off",
-        }
+        memory_enabled = (
+            research_memory_required
+            or os.getenv("GARVIS_MEMORY_ENABLED", "1").casefold()
+            not in {
+                "0",
+                "false",
+                "no",
+                "off",
+            }
+        )
         if memory_enabled:
             try:
                 from garvis.memory_lifecycle import (
@@ -308,14 +352,22 @@ class LocalLanguageRuntime:
 
                 memory_store = MemoryStore.from_environment()
                 ensure_core_memories(memory_store)
-                core_context = render_core_context(memory_store)
-                recalled_context = memory_store.render_context(
-                    envelope.request,
+                recalled_context = _recall_runtime_memory_context(
+                    memory_store,
+                    envelope,
                     session_id=self.session_id,
+                    research_memory_required=research_memory_required,
                 )
-                memory_context = "\n".join(
-                    part for part in (core_context, recalled_context) if part
-                )
+
+                if research_memory_required:
+                    memory_context = recalled_context
+                else:
+                    core_context = render_core_context(memory_store)
+                    memory_context = "\n".join(
+                        part
+                        for part in (core_context, recalled_context)
+                        if part
+                    )
                 memory_store.remember(
                     envelope.request,
                     session_id=self.session_id,
@@ -329,6 +381,12 @@ class LocalLanguageRuntime:
                 )
             except Exception as exc:
                 memory_store = None
+
+                if research_memory_required:
+                    raise RuntimeError(
+                        "mandatory research memory unavailable"
+                    ) from exc
+
                 if os.getenv("GARVIS_MEMORY_DEBUG", "0") == "1":
                     print(f"GARVIS memory warning: {exc}", file=sys.stderr)
 

--- a/src/garvis/memory_lifecycle.py
+++ b/src/garvis/memory_lifecycle.py
@@ -67,11 +67,51 @@ def _tokens(text: str) -> set[str]:
     }
 
 
+_RESEARCH_MEMORY_PATTERNS = (
+    re.compile(
+        r"\b(?:search|browse|research|look\s+up|find\s+online|investigate)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(?:latest|today|current|currently|recent|recently|news|weather|"
+        r"forecast|live\s+score|stock\s+price|exchange\s+rate|"
+        r"released?|release\s+changes?)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(?:evidence|peer[- ]reviewed|stud(?:y|ies)|papers?|literature|"
+        r"citations?|empirical|experimental|reproducible|reproduction|"
+        r"benchmark|dataset)\b",
+        re.IGNORECASE,
+    ),
+)
+
+def research_memory_required(message: str) -> bool:
+    """High-recall classifier for advisory research-memory consultation.
+
+    This classifier does not grant network access, execution authority,
+    evidence status, or approval. It decides only whether canonical memory
+    must be consulted before research-like reasoning.
+    """
+
+    clean = " ".join(message.strip().split())
+
+    if not clean:
+        return False
+
+    return any(
+        pattern.search(clean)
+        for pattern in _RESEARCH_MEMORY_PATTERNS
+    )
+
+
 class MemoryKind(str, Enum):
     WORKING = "working"
     EPISODIC = "episodic"
     SEMANTIC = "semantic"
     PROCEDURAL = "procedural"
+    PROSPECTIVE = "prospective"
+    SIMULATION = "simulation"
     CORE = "core"
     TRACE = "trace"
 
@@ -114,6 +154,8 @@ class MemoryPolicy:
             MemoryKind.EPISODIC: self.episodic_half_life_hours,
             MemoryKind.SEMANTIC: self.semantic_half_life_hours,
             MemoryKind.PROCEDURAL: self.procedural_half_life_hours,
+            MemoryKind.PROSPECTIVE: self.procedural_half_life_hours,
+            MemoryKind.SIMULATION: self.working_half_life_hours,
             MemoryKind.CORE: self.core_half_life_hours,
             MemoryKind.TRACE: self.core_half_life_hours,
         }[kind]
@@ -155,6 +197,18 @@ class RecallResult:
     relevance: float
     retention: float
     score: float
+
+
+@dataclass(frozen=True)
+class MemoryControlSignal:
+    cue: str
+    procedural_candidates: tuple[RecallResult, ...]
+    prospective_triggers: tuple[RecallResult, ...]
+    contradiction_observed: bool
+    foreground_required: bool
+    execution_authority: bool
+    silent_consolidation_allowed: bool
+    reason: str
 
 
 @dataclass(frozen=True)
@@ -353,6 +407,19 @@ class MemoryStore:
         clean = _clean(content)
         if not clean:
             raise ValueError("memory content must not be empty")
+
+        if (
+            kind is MemoryKind.SIMULATION
+            and evidence_status
+            not in (
+                EvidenceStatus.PROVISIONAL,
+                EvidenceStatus.MODEL_GENERATED,
+            )
+        ):
+            raise ValueError(
+                "simulation memory cannot be classified as verified or "
+                "evidence-supported reality"
+            )
         if not session_id.strip():
             raise ValueError("session_id must not be empty")
         now = _now()
@@ -518,6 +585,277 @@ class MemoryStore:
             self._render(result)
             for result in self.recall(query, session_id=session_id)
         )
+
+    def recall_kind(
+        self,
+        query: str,
+        kind: MemoryKind,
+        *,
+        session_id: str = "default",
+        record_retrieval: bool = True,
+    ) -> tuple[RecallResult, ...]:
+        clean_query = _clean(query)
+        if not clean_query:
+            return ()
+
+        rows = self.connection.execute(
+            """
+            SELECT * FROM memories
+            WHERE session_id IN (?, 'global')
+              AND kind = ?
+              AND state IN (?, ?, ?)
+              AND content <> ''
+            """,
+            (
+                session_id,
+                kind.value,
+                MemoryState.ACTIVE.value,
+                MemoryState.CONSOLIDATED.value,
+                MemoryState.LATENT.value,
+            ),
+        ).fetchall()
+
+        results: list[RecallResult] = []
+
+        for row in rows:
+            memory = self._row(row)
+            relevance = lexical_relevance(clean_query, memory)
+            if relevance <= 0.0:
+                continue
+
+            retention = retention_score(
+                memory,
+                policy=self.policy,
+            )
+
+            evidence_bonus = {
+                EvidenceStatus.VERIFIED: 0.12,
+                EvidenceStatus.EVIDENCE_SUPPORTED: 0.08,
+                EvidenceStatus.USER_SUPPLIED: 0.03,
+                EvidenceStatus.PROVISIONAL: 0.0,
+                EvidenceStatus.MODEL_GENERATED: -0.05,
+            }[memory.evidence_status]
+
+            score = _clamp(
+                0.60 * relevance
+                + 0.35 * retention
+                + evidence_bonus
+                + 0.05 * memory.salience
+            )
+
+            if score >= 0.10:
+                results.append(
+                    RecallResult(
+                        memory=memory,
+                        relevance=relevance,
+                        retention=retention,
+                        score=score,
+                    )
+                )
+
+        results.sort(
+            key=lambda item: (-item.score, item.memory.id)
+        )
+
+        selected: list[RecallResult] = []
+        used = 0
+
+        for result in results:
+            rendered = self._render(result)
+            if used + len(rendered) + 1 > self.policy.prompt_budget_chars:
+                continue
+
+            selected.append(result)
+            used += len(rendered) + 1
+
+            if len(selected) >= self.policy.max_recall_items:
+                break
+
+        if record_retrieval and selected:
+            ids = [item.memory.id for item in selected]
+            placeholders = ",".join("?" for _ in ids)
+            self.connection.execute(
+                f"""
+                UPDATE memories
+                SET retrieval_count = retrieval_count + 1,
+                    updated_at = ?
+                WHERE id IN ({placeholders})
+                """,
+                (_iso(_now()), *ids),
+            )
+            self.connection.commit()
+
+        return tuple(selected)
+
+    def automatic_memory_control(
+        self,
+        cue: str,
+        *,
+        session_id: str = "default",
+        contradiction_observed: bool = False,
+    ) -> MemoryControlSignal:
+        """Evaluate automatic recall without granting action authority.
+
+        Procedural memory may become available in the background without
+        requiring foreground interruption.
+
+        A matching prospective intention or an externally observed
+        contradiction requires foreground re-engagement.
+
+        Automatic recall does not increment retrieval counts, consolidate
+        memory, execute actions, or silently rewrite remembered content.
+        """
+
+        procedural = self.recall_kind(
+            cue,
+            MemoryKind.PROCEDURAL,
+            session_id=session_id,
+            record_retrieval=False,
+        )
+
+        prospective = self.recall_kind(
+            cue,
+            MemoryKind.PROSPECTIVE,
+            session_id=session_id,
+            record_retrieval=False,
+        )
+
+        foreground_required = (
+            contradiction_observed or bool(prospective)
+        )
+
+        if contradiction_observed and prospective:
+            reason = "contradiction_and_prospective_cue"
+        elif contradiction_observed:
+            reason = "contradiction"
+        elif prospective:
+            reason = "prospective_cue"
+        elif procedural:
+            reason = "procedural_candidate_available"
+        else:
+            reason = "no_matching_memory"
+
+        return MemoryControlSignal(
+            cue=_clean(cue),
+            procedural_candidates=procedural,
+            prospective_triggers=prospective,
+            contradiction_observed=contradiction_observed,
+            foreground_required=foreground_required,
+            execution_authority=False,
+            silent_consolidation_allowed=False,
+            reason=reason,
+        )
+
+    def recall_for_research(
+        self,
+        query: str,
+        *,
+        session_id: str = "default",
+        record_retrieval: bool = True,
+    ) -> tuple[RecallResult, ...]:
+        """Recall memory for research with protected core memory first.
+
+        Research always consults memory. Protected core memory is surfaced
+        before ordinary relevance-ranked recall so provenance and durable
+        boundaries remain visible even when the current query uses different
+        vocabulary.
+
+        Memory remains context only. Recall does not grant execution,
+        authorization, merge, deployment, or truth status.
+        """
+
+        ordinary = list(
+            self.recall(
+                query,
+                session_id=session_id,
+                record_retrieval=record_retrieval,
+            )
+        )
+        ordinary_ids = {result.memory.id for result in ordinary}
+
+        rows = self.connection.execute(
+            """
+            SELECT * FROM memories
+            WHERE session_id IN (?, 'global')
+              AND kind = ?
+              AND protected = 1
+              AND state IN (?, ?, ?)
+              AND content <> ''
+            ORDER BY id
+            """,
+            (
+                session_id,
+                MemoryKind.CORE.value,
+                MemoryState.ACTIVE.value,
+                MemoryState.CONSOLIDATED.value,
+                MemoryState.LATENT.value,
+            ),
+        ).fetchall()
+
+        protected_core: list[RecallResult] = []
+        for row in rows:
+            memory = self._row(row)
+            if memory.id in ordinary_ids:
+                continue
+            protected_core.append(
+                RecallResult(
+                    memory=memory,
+                    relevance=0.0,
+                    retention=retention_score(
+                        memory,
+                        policy=self.policy,
+                    ),
+                    score=1.0,
+                )
+            )
+
+        candidates = protected_core + ordinary
+        selected: list[RecallResult] = []
+        used = 0
+
+        for result in candidates:
+            rendered = self._render(result)
+            if used + len(rendered) + 1 > self.policy.prompt_budget_chars:
+                continue
+            selected.append(result)
+            used += len(rendered) + 1
+            if len(selected) >= self.policy.max_recall_items:
+                break
+
+        return tuple(selected)
+
+    def render_research_context(
+        self,
+        query: str,
+        *,
+        session_id: str = "default",
+    ) -> str:
+        """Render mandatory memory context for research."""
+
+        recalled = self.recall_for_research(
+            query,
+            session_id=session_id,
+            record_retrieval=False,
+        )
+
+        lines = [
+            (
+                "[research-memory-control "
+                "consulted=true "
+                "prominence=required "
+                "execution_authority=false "
+                "simulation_is_evidence=false]"
+            )
+        ]
+
+        if recalled:
+            lines.extend(self._render(result) for result in recalled)
+        else:
+            lines.append(
+                "[research-memory] no protected or relevant memory available"
+            )
+
+        return "\n".join(lines)
 
     def maintain(
         self,

--- a/src/garvis/research_hypercube_bridge.py
+++ b/src/garvis/research_hypercube_bridge.py
@@ -21,6 +21,8 @@ Python 3.9 compatible.
 
 from __future__ import annotations
 
+from typing import Callable
+
 import ast
 import asyncio
 import json
@@ -36,6 +38,8 @@ from typing import Any, Mapping, Optional, Protocol, Sequence, Tuple
 from garvis.assistant import GarvisAssistant
 from garvis.hypercube_snapshot import validate_hypercube_snapshot
 from garvis.internet_research import InternetResearchClient, ResearchReport
+from garvis.core_memory import ensure_core_memories
+from garvis.memory_lifecycle import MemoryStore
 from garvis.upgrade_research import (
     EvidenceLedger,
     ResearchEvidence,
@@ -368,7 +372,7 @@ def _source_context(report: ResearchReport, evidence: Sequence[ResearchEvidence]
     return "\n".join(parts)
 
 
-def _packet_prompt(query: str, repository_context: str, source_context: str) -> str:
+def _packet_prompt(query: str, repository_context: str, source_context: str, memory_context: str) -> str:
     return f"""
 You are GARVIS, created and owned by Adrien D. Thomas.
 
@@ -377,6 +381,14 @@ Research objective:
 
 Repository state:
 {repository_context}
+
+ADVISORY RESEARCH MEMORY — NOT SOURCE EVIDENCE:
+{memory_context}
+
+BOUNDARY:
+Recalled memory may inform reasoning and foreground review.
+It must not be counted as a retrieved source, evidence-ledger record,
+verified empirical result, execution authorization, or truth guarantee.
 
 {source_context}
 
@@ -433,6 +445,31 @@ def _atomic_write(path: Path, payload: Mapping[str, Any]) -> None:
         raise
 
 
+def _mandatory_research_memory_context(
+    query: str,
+) -> str:
+    """Load mandatory advisory memory before network research."""
+
+    try:
+        with MemoryStore.from_environment() as store:
+            ensure_core_memories(store)
+            context = store.render_research_context(
+                query,
+                session_id="research-hypercube",
+            )
+    except Exception as exc:
+        raise BridgeError(
+            "mandatory research memory unavailable"
+        ) from exc
+
+    if not context.strip():
+        raise BridgeError(
+            "mandatory research memory returned empty context"
+        )
+
+    return context
+
+
 class HypercubeResearchBridge:
     """Run one internet-research, GARVIS-reasoning, Hypercube-verification cycle."""
 
@@ -444,11 +481,18 @@ class HypercubeResearchBridge:
         ledger_path: Path,
         research_client: Optional[ResearchClient] = None,
         assistant: Optional[ReasoningAssistant] = None,
+        memory_context_provider: Optional[
+            Callable[[str], str]
+        ] = None,
     ) -> None:
         self.repository_root = repository_root
         self.model = model
         self.ledger = EvidenceLedger(ledger_path)
         self.research_client = research_client or InternetResearchClient()
+        self.memory_context_provider = (
+            memory_context_provider
+            or _mandatory_research_memory_context
+        )
         self.assistant = assistant or GarvisAssistant(
             model=model,
             persist_memory=False,
@@ -460,6 +504,20 @@ class HypercubeResearchBridge:
         if not clean_query:
             raise BridgeError("research query must not be empty")
 
+        try:
+            memory_context = self.memory_context_provider(clean_query)
+        except BridgeError:
+            raise
+        except Exception as exc:
+            raise BridgeError(
+                "mandatory research memory unavailable"
+            ) from exc
+
+        if not memory_context.strip():
+            raise BridgeError(
+                "mandatory research memory returned empty context"
+            )
+
         report = self.research_client.research(clean_query)
         if not report.sources:
             raise BridgeError("internet research returned no sources")
@@ -467,7 +525,12 @@ class HypercubeResearchBridge:
         stored_evidence = _evidence_records(report, ledger=self.ledger)
         repository_context = _repository_context(self.repository_root)
         source_context = _source_context(report, stored_evidence)
-        prompt = _packet_prompt(clean_query, repository_context, source_context)
+        prompt = _packet_prompt(
+            clean_query,
+            repository_context,
+            source_context,
+            memory_context,
+        )
 
         reply = await self.assistant.respond(
             prompt,

--- a/src/garvis/resilient_runtime.py
+++ b/src/garvis/resilient_runtime.py
@@ -9,7 +9,15 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 from openai import OpenAI
 from tools.garvis_resilience import SessionLedger, build_context, call_with_retry
 
-from .assistant import GARVIS_INSTRUCTIONS, GarvisReply, assess_request
+from .assistant import (
+    GARVIS_INSTRUCTIONS,
+    GarvisReply,
+    ResearchMemoryProvider,
+    _mandatory_remote_research_memory_context,
+    _remote_research_memory_required,
+    _render_remote_research_memory_instructions,
+    assess_request,
+)
 from .repository_context import ground_message, should_ground_repository
 
 Message = Dict[str, str]
@@ -62,6 +70,9 @@ class ResilientGarvisRuntime:
         ledger: Optional[Any] = None,
         build_messages: BuildContextCallable = build_context,
         call_model: CallModelCallable = call_with_retry,
+        research_memory_provider: Optional[
+            ResearchMemoryProvider
+        ] = None,
     ) -> None:
         clean_session = session_name.strip()
         if not clean_session:
@@ -76,6 +87,10 @@ class ResilientGarvisRuntime:
         self.ledger = ledger or SessionLedger(clean_session)
         self._build_messages = build_messages
         self._call_model = call_model
+        self._research_memory_provider = (
+            research_memory_provider
+            or _mandatory_remote_research_memory_context
+        )
 
     async def respond(
         self,
@@ -97,12 +112,38 @@ class ResilientGarvisRuntime:
         # If the process dies after this line, Adrien's message survives.
         self.ledger.append("user", user_text)
 
+        research_memory = ""
+
+        if _remote_research_memory_required(user_text):
+            try:
+                research_memory = self._research_memory_provider(
+                    user_text,
+                    self.session_name,
+                )
+            except Exception as exc:
+                raise RuntimeError(
+                    "mandatory research memory unavailable"
+                ) from exc
+
+            if not research_memory.strip():
+                raise RuntimeError(
+                    "mandatory research memory returned empty context"
+                )
+
         system_prompt = GARVIS_INSTRUCTIONS
         if system_extension:
             system_prompt = (
                 f"{system_prompt}\n\n"
                 "LOCAL TERMUX CONSTITUTIONAL CONTEXT:\n"
                 f"{system_extension}"
+            )
+
+        if research_memory:
+            system_prompt = (
+                f"{system_prompt}\n\n"
+                + _render_remote_research_memory_instructions(
+                    research_memory
+                )
             )
 
         # Integration point 3: only the bounded recent ledger window is sent.

--- a/tests/garvis/test_assistant.py
+++ b/tests/garvis/test_assistant.py
@@ -124,3 +124,137 @@ async def test_empty_user_message_is_rejected() -> None:
 
     with pytest.raises(ValueError, match="message must not be empty"):
         await assistant.respond("   ")
+
+
+# REMOTE CANONICAL RESEARCH MEMORY TESTS
+
+@pytest.mark.asyncio
+async def test_remote_research_memory_is_transient_even_without_session_persistence() -> None:
+    sentinel = "REMOTE_RESEARCH_MEMORY_SENTINEL_817"
+    provider_calls: list[tuple[str, str]] = []
+
+    def memory_provider(query: str, session_id: str) -> str:
+        provider_calls.append((query, session_id))
+        return sentinel
+
+    runner = FakeRunner("research response")
+
+    assistant = GarvisAssistant(
+        runner=runner,
+        persist_memory=False,
+        research_memory_provider=memory_provider,
+    )
+
+    prompt = "Research current Python release changes"
+
+    reply = await assistant.respond(
+        prompt,
+        session_id="remote-memory-test",
+    )
+
+    assert reply.text == "research response"
+    assert provider_calls == [
+        (prompt, "remote-memory-test")
+    ]
+
+    call = runner.calls[0]
+
+    assert call["session"] is None
+    assert call["input"] == prompt
+    assert sentinel not in call["input"]
+
+    transient_agent = call["agent"]
+
+    assert transient_agent is not assistant.agent
+    assert sentinel in str(transient_agent.instructions)
+    assert "ADVISORY CONTEXT ONLY" in str(
+        transient_agent.instructions
+    )
+    assert "not retrieved source evidence" in str(
+        transient_agent.instructions
+    ).lower()
+
+    assert sentinel not in str(assistant.agent.instructions)
+
+
+@pytest.mark.asyncio
+async def test_remote_research_memory_failure_blocks_provider_inference() -> None:
+    runner = FakeRunner("must not execute")
+
+    def unavailable_memory(
+        query: str,
+        session_id: str,
+    ) -> str:
+        del query, session_id
+        raise RuntimeError("memory unavailable")
+
+    assistant = GarvisAssistant(
+        runner=runner,
+        persist_memory=False,
+        research_memory_provider=unavailable_memory,
+    )
+
+    with pytest.raises(
+        GarvisResponseError,
+        match="mandatory research memory unavailable",
+    ):
+        await assistant.respond(
+            "Research current lattice evidence",
+            session_id="remote-memory-test",
+        )
+
+    assert runner.calls == []
+
+
+@pytest.mark.asyncio
+async def test_nonresearch_remote_reasoning_does_not_require_research_memory() -> None:
+    runner = FakeRunner("ordinary answer")
+    provider_calls: list[str] = []
+
+    def memory_provider(
+        query: str,
+        session_id: str,
+    ) -> str:
+        provider_calls.append(query + session_id)
+        return "should not be used"
+
+    assistant = GarvisAssistant(
+        runner=runner,
+        persist_memory=False,
+        research_memory_provider=memory_provider,
+    )
+
+    await assistant.respond(
+        "Explain how drywall compound cures",
+        session_id="ordinary",
+    )
+
+    assert provider_calls == []
+    assert runner.calls[0]["agent"] is assistant.agent
+
+
+
+@pytest.mark.asyncio
+async def test_remote_primary_evidence_phrase_requires_research_memory() -> None:
+    calls: list[str] = []
+
+    def provider(query: str, session_id: str) -> str:
+        calls.append(query)
+        return "ADVISORY_MEMORY_CONTEXT"
+
+    runner = FakeRunner("research answer")
+
+    assistant = GarvisAssistant(
+        runner=runner,
+        persist_memory=False,
+        research_memory_provider=provider,
+    )
+
+    prompt = "Find recent primary evidence about memory consolidation"
+
+    await assistant.respond(
+        prompt,
+        session_id="classifier-regression",
+    )
+
+    assert calls == [prompt]

--- a/tests/garvis/test_lattice_cognitive_cycle.py
+++ b/tests/garvis/test_lattice_cognitive_cycle.py
@@ -1,6 +1,7 @@
 import pytest
 
 from garvis.evidence_envelope import build_evidence_envelope
+from garvis.memory_lifecycle import MemoryControlSignal
 from garvis.lattice_cognition import (
     CognitiveCycleStage,
     PulsePhase,
@@ -172,6 +173,152 @@ def test_cycle_number_changes_cycle_hash() -> None:
         second.pulse.compute_sha256()
     )
     assert first.cycle_sha256 != second.cycle_sha256
+
+
+def _memory_control(
+    *,
+    foreground_required: bool = False,
+    contradiction_observed: bool = False,
+    execution_authority: bool = False,
+    silent_consolidation_allowed: bool = False,
+    reason: str = "procedural_candidate_available",
+) -> MemoryControlSignal:
+    return MemoryControlSignal(
+        cue="memory control test cue",
+        procedural_candidates=(),
+        prospective_triggers=(),
+        contradiction_observed=contradiction_observed,
+        foreground_required=foreground_required,
+        execution_authority=execution_authority,
+        silent_consolidation_allowed=silent_consolidation_allowed,
+        reason=reason,
+    )
+
+
+def test_memory_control_does_not_rewrite_evidence_or_consolidation() -> None:
+    baseline = run_lattice_cognitive_cycle(
+        envelope=build_strong_envelope(),
+        cycle=11,
+    )
+
+    controlled = run_lattice_cognitive_cycle(
+        envelope=build_strong_envelope(),
+        cycle=11,
+        memory_control=_memory_control(),
+    )
+
+    assert controlled.envelope_sha256 == baseline.envelope_sha256
+    assert controlled.assessment == baseline.assessment
+    assert (
+        controlled.consolidated_memory.memory.compute_sha256()
+        == baseline.consolidated_memory.memory.compute_sha256()
+    )
+    assert controlled.recall == baseline.recall
+    assert (
+        controlled.evidence_proposal_eligible
+        == baseline.evidence_proposal_eligible
+    )
+    assert controlled.decision == baseline.decision
+    assert controlled.external_action_allowed is False
+
+
+def test_memory_foreground_signal_interrupts_proposal_only() -> None:
+    result = run_lattice_cognitive_cycle(
+        envelope=build_strong_envelope(),
+        cycle=12,
+        memory_control=_memory_control(
+            foreground_required=True,
+            reason="prospective_cue",
+        ),
+    )
+
+    assert result.evidence_proposal_eligible is True
+    assert result.proposal_eligible is False
+    assert result.decision == "MEMORY_FOREGROUND_REVIEW_REQUIRED"
+    assert result.external_action_allowed is False
+
+
+def test_contradiction_memory_signal_requires_foreground_review() -> None:
+    result = run_lattice_cognitive_cycle(
+        envelope=build_strong_envelope(),
+        cycle=13,
+        memory_control=_memory_control(
+            foreground_required=True,
+            contradiction_observed=True,
+            reason="contradiction",
+        ),
+    )
+
+    assert result.memory_control is not None
+    assert result.memory_control.contradiction_observed is True
+    assert result.proposal_eligible is False
+    assert result.decision == "MEMORY_FOREGROUND_REVIEW_REQUIRED"
+    assert result.external_action_allowed is False
+
+
+def test_memory_control_cannot_grant_execution_authority() -> None:
+    with pytest.raises(
+        ValueError,
+        match="memory control cannot grant execution authority",
+    ):
+        run_lattice_cognitive_cycle(
+            envelope=build_strong_envelope(),
+            cycle=14,
+            memory_control=_memory_control(
+                execution_authority=True,
+            ),
+        )
+
+
+def test_memory_control_cannot_enable_silent_consolidation() -> None:
+    with pytest.raises(
+        ValueError,
+        match="memory control cannot authorize silent consolidation",
+    ):
+        run_lattice_cognitive_cycle(
+            envelope=build_strong_envelope(),
+            cycle=15,
+            memory_control=_memory_control(
+                silent_consolidation_allowed=True,
+            ),
+        )
+
+
+def test_memory_control_stage_precedes_proposal_stage() -> None:
+    result = run_lattice_cognitive_cycle(
+        envelope=build_strong_envelope(),
+        cycle=16,
+        memory_control=_memory_control(),
+    )
+
+    memory_index = result.completed_stages.index(
+        CognitiveCycleStage.EVALUATE_MEMORY_CONTROL
+    )
+    proposal_index = result.completed_stages.index(
+        CognitiveCycleStage.EVALUATE_PROPOSAL
+    )
+
+    assert memory_index < proposal_index
+
+
+def test_memory_control_is_bound_into_cycle_hash_not_evidence_hash() -> None:
+    baseline = run_lattice_cognitive_cycle(
+        envelope=build_strong_envelope(),
+        cycle=17,
+    )
+
+    interrupted = run_lattice_cognitive_cycle(
+        envelope=build_strong_envelope(),
+        cycle=17,
+        memory_control=_memory_control(
+            foreground_required=True,
+            reason="prospective_cue",
+        ),
+    )
+
+    assert interrupted.envelope_sha256 == baseline.envelope_sha256
+    assert interrupted.assessment == baseline.assessment
+    assert interrupted.cycle_sha256 != baseline.cycle_sha256
 
 
 def test_cycle_has_no_execution_interface() -> None:

--- a/tests/garvis/test_local_language_runtime.py
+++ b/tests/garvis/test_local_language_runtime.py
@@ -70,3 +70,96 @@ class LocalLanguageRuntimeTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+# CANONICAL RESEARCH MEMORY RUNTIME TESTS
+
+def test_epistemic_request_requires_research_memory_context() -> None:
+    from garvis.local_language_runtime import (
+        _recall_runtime_memory_context,
+        _research_memory_required,
+        classify_request,
+    )
+
+    class FakeMemory:
+        def __init__(self) -> None:
+            self.research_calls = 0
+            self.general_calls = 0
+
+        def render_research_context(
+            self,
+            query: str,
+            *,
+            session_id: str,
+        ) -> str:
+            self.research_calls += 1
+            return (
+                "[research-memory-control consulted=true "
+                "execution_authority=false] "
+                + query
+                + " "
+                + session_id
+            )
+
+        def render_context(
+            self,
+            query: str,
+            *,
+            session_id: str,
+        ) -> str:
+            self.general_calls += 1
+            return "GENERAL " + query + " " + session_id
+
+    envelope = classify_request(
+        "research procedural memory and evidence boundaries"
+    )
+
+    required = _research_memory_required(envelope, "")
+    fake = FakeMemory()
+
+    context = _recall_runtime_memory_context(
+        fake,
+        envelope,
+        session_id="research-test",
+        research_memory_required=required,
+    )
+
+    assert required is True
+    assert "consulted=true" in context
+    assert "execution_authority=false" in context
+    assert fake.research_calls == 1
+    assert fake.general_calls == 0
+
+
+def test_external_research_context_forces_research_memory_mode() -> None:
+    from garvis.local_language_runtime import (
+        _research_memory_required,
+        classify_request,
+    )
+
+    envelope = classify_request(
+        "What are current drywall prices?"
+    )
+
+    assert envelope.destination != "epistemic_registry"
+    assert (
+        _research_memory_required(
+            envelope,
+            "external internet evidence",
+        )
+        is True
+    )
+
+
+
+def test_recent_release_question_requires_research_memory() -> None:
+    from garvis.local_language_runtime import (
+        _research_memory_required,
+        classify_request,
+    )
+
+    envelope = classify_request(
+        "Find out whether Python 3.14 has been released"
+    )
+
+    assert _research_memory_required(envelope, "") is True

--- a/tests/garvis/test_memory_lifecycle.py
+++ b/tests/garvis/test_memory_lifecycle.py
@@ -105,6 +105,198 @@ class MemoryLifecycleTests(unittest.TestCase):
         self.assertNotEqual(updated.state, MemoryState.TRACE)
         self.assertTrue(updated.content)
 
+    def test_research_memory_always_surfaces_protected_core(self) -> None:
+        self.store.remember(
+            "Protected provenance must remain visible during research",
+            session_id="global",
+            kind=MemoryKind.CORE,
+            evidence_status=EvidenceStatus.USER_SUPPLIED,
+            source="research_memory_test",
+            protected=True,
+        )
+
+        context = self.store.render_research_context(
+            "a completely unrelated experiment"
+        )
+
+        self.assertIn("consulted=true", context)
+        self.assertIn("prominence=required", context)
+        self.assertIn("execution_authority=false", context)
+        self.assertIn(
+            "Protected provenance must remain visible during research",
+            context,
+        )
+
+    def test_prospective_memory_is_first_class_and_recallable(self) -> None:
+        self.store.remember(
+            "When contradiction appears return control to the foreground",
+            kind=MemoryKind.PROSPECTIVE,
+            evidence_status=EvidenceStatus.USER_SUPPLIED,
+            tags=("contradiction", "foreground", "intention"),
+        )
+
+        context = self.store.render_research_context(
+            "contradiction foreground"
+        )
+
+        self.assertIn("kind=prospective", context)
+        self.assertIn(
+            "return control to the foreground",
+            context,
+        )
+
+    def test_simulation_memory_cannot_claim_verified_evidence(self) -> None:
+        with self.assertRaises(ValueError):
+            self.store.remember(
+                "Imagined future result",
+                kind=MemoryKind.SIMULATION,
+                evidence_status=EvidenceStatus.VERIFIED,
+            )
+
+        simulation = self.store.remember(
+            "Imagined future result",
+            kind=MemoryKind.SIMULATION,
+            evidence_status=EvidenceStatus.MODEL_GENERATED,
+        )
+
+        self.assertEqual(
+            simulation.evidence_status,
+            EvidenceStatus.MODEL_GENERATED,
+        )
+
+        context = self.store.render_research_context(
+            "imagined future result"
+        )
+
+        self.assertIn("simulation_is_evidence=false", context)
+        self.assertIn("kind=simulation", context)
+        self.assertIn(
+            "evidence=model_generated_unverified",
+            context,
+        )
+
+    def test_procedural_memory_can_be_background_candidate(self) -> None:
+        record = self.store.remember(
+            "For build verification inspect test output and status",
+            kind=MemoryKind.PROCEDURAL,
+            evidence_status=EvidenceStatus.USER_SUPPLIED,
+            tags=("build", "verification", "procedure"),
+        )
+
+        before = self.store.get(record.id)
+
+        signal = self.store.automatic_memory_control(
+            "build verification test output"
+        )
+
+        after = self.store.get(record.id)
+
+        self.assertTrue(signal.procedural_candidates)
+        self.assertFalse(signal.prospective_triggers)
+        self.assertFalse(signal.foreground_required)
+        self.assertFalse(signal.execution_authority)
+        self.assertFalse(signal.silent_consolidation_allowed)
+        self.assertEqual(
+            signal.reason,
+            "procedural_candidate_available",
+        )
+        self.assertEqual(
+            before.retrieval_count,
+            after.retrieval_count,
+        )
+
+    def test_prospective_cue_requires_foreground_reengagement(self) -> None:
+        self.store.remember(
+            "When the merge head changes return to explicit review",
+            kind=MemoryKind.PROSPECTIVE,
+            evidence_status=EvidenceStatus.USER_SUPPLIED,
+            tags=("merge", "head", "review"),
+        )
+
+        signal = self.store.automatic_memory_control(
+            "merge head changes"
+        )
+
+        self.assertTrue(signal.prospective_triggers)
+        self.assertTrue(signal.foreground_required)
+        self.assertFalse(signal.execution_authority)
+        self.assertEqual(
+            signal.reason,
+            "prospective_cue",
+        )
+
+    def test_contradiction_forces_foreground_reengagement(self) -> None:
+        signal = self.store.automatic_memory_control(
+            "unrelated observation",
+            contradiction_observed=True,
+        )
+
+        self.assertTrue(signal.contradiction_observed)
+        self.assertTrue(signal.foreground_required)
+        self.assertFalse(signal.execution_authority)
+        self.assertFalse(signal.silent_consolidation_allowed)
+        self.assertEqual(signal.reason, "contradiction")
+
+    def test_contradiction_does_not_silently_strengthen_memory(self) -> None:
+        record = self.store.remember(
+            "Routine procedure remains bounded by observation",
+            kind=MemoryKind.PROCEDURAL,
+            evidence_status=EvidenceStatus.USER_SUPPLIED,
+            tags=("routine", "observation"),
+        )
+
+        before = self.store.get(record.id)
+
+        signal = self.store.automatic_memory_control(
+            "routine observation",
+            contradiction_observed=True,
+        )
+
+        after = self.store.get(record.id)
+
+        self.assertTrue(signal.foreground_required)
+        self.assertFalse(signal.silent_consolidation_allowed)
+        self.assertEqual(
+            before.retrieval_count,
+            after.retrieval_count,
+        )
+        self.assertEqual(
+            before.repetition_count,
+            after.repetition_count,
+        )
+        self.assertEqual(before.state, after.state)
+        self.assertEqual(before.content, after.content)
+
+    def test_research_context_does_not_silently_strengthen_retrieval(self) -> None:
+        record = self.store.remember(
+            "Research memory consultation must remain observational",
+            kind=MemoryKind.SEMANTIC,
+            evidence_status=EvidenceStatus.USER_SUPPLIED,
+            tags=("research", "memory", "observation"),
+        )
+
+        before = self.store.get(record.id)
+
+        context = self.store.render_research_context(
+            "research memory observation"
+        )
+
+        after = self.store.get(record.id)
+
+        self.assertIn(
+            "Research memory consultation must remain observational",
+            context,
+        )
+        self.assertEqual(
+            before.retrieval_count,
+            after.retrieval_count,
+        )
+        self.assertEqual(
+            before.repetition_count,
+            after.repetition_count,
+        )
+        self.assertEqual(before.state, after.state)
+
     def test_explicit_forgetting_requires_token(self) -> None:
         record = self.store.remember("Only forget with confirmation")
         with self.assertRaises(PermissionError):
@@ -119,3 +311,36 @@ class MemoryLifecycleTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+
+def test_research_memory_classifier_covers_adversarial_research_language() -> None:
+    from garvis.memory_lifecycle import research_memory_required
+
+    positives = (
+        "Research current Python release changes",
+        "Browse the web for current Python release changes",
+        "Search the internet for current drywall prices",
+        "Look up the latest Python documentation online",
+        "Check today's weather in Philadelphia",
+        "What is today's weather in Philadelphia?",
+        "What are current drywall prices?",
+        "Find recent primary evidence about memory consolidation",
+        "Compare the latest studies on procedural memory",
+        "Investigate current evidence for this hypothesis",
+        "Find out whether Python 3.14 has been released",
+        "What changed recently in OpenAI API documentation?",
+        "Research procedural memory architecture",
+    )
+
+    negatives = (
+        "Explain how drywall compound cures",
+        "Summarize this local file",
+        "Calculate 1/phi + 1/phi^2",
+    )
+
+    for message in positives:
+        assert research_memory_required(message), message
+
+    for message in negatives:
+        assert not research_memory_required(message), message

--- a/tests/garvis/test_research_hypercube_bridge.py
+++ b/tests/garvis/test_research_hypercube_bridge.py
@@ -228,3 +228,121 @@ async def test_model_cannot_self_certify_failed_math(tmp_path: Path) -> None:
     assert result["math_verification_passed"] is False
     assert result["usable_for_mathematical_followup"] is False
     assert result["model_output_is_self_certifying"] is False
+
+
+# CANONICAL RESEARCH MEMORY BRIDGE TESTS
+
+def test_research_memory_reaches_reasoning_not_evidence_ledger(
+    tmp_path,
+) -> None:
+    import asyncio
+    import json
+
+    sentinel = (
+        "MEMORY_ONLY_SENTINEL_NOT_SOURCE_EVIDENCE_9173"
+    )
+
+    class CapturingAssistant:
+        def __init__(self) -> None:
+            self.prompt = ""
+
+        async def respond(
+            self,
+            prompt: str,
+            *,
+            session_id: str,
+        ):
+            self.prompt = prompt
+
+            class Reply:
+                text = json.dumps(
+                    {
+                        "snapshot": valid_snapshot(),
+                        "math_claims": packet()["math_claims"],
+                    }
+                )
+
+            assert session_id == "research-hypercube"
+            return Reply()
+
+    assistant = CapturingAssistant()
+    ledger_path = tmp_path / "evidence.json"
+    output_path = tmp_path / "result.json"
+
+    bridge = HypercubeResearchBridge(
+        repository_root=tmp_path,
+        model="test-model",
+        ledger_path=ledger_path,
+        research_client=FakeResearchClient(),
+        assistant=assistant,
+        memory_context_provider=lambda _query: sentinel,
+    )
+
+    result = asyncio.run(
+        bridge.run(
+            "research memory evidence boundary",
+            output_path,
+        )
+    )
+
+    assert "ADVISORY RESEARCH MEMORY" in assistant.prompt
+    assert sentinel in assistant.prompt
+    assert "NOT SOURCE EVIDENCE" in assistant.prompt
+
+    assert result["source_count"] == 1
+    assert len(result["evidence_record_ids"]) == 1
+    assert result["model_output_is_self_certifying"] is False
+
+    ledger_text = ledger_path.read_text()
+    assert sentinel not in ledger_text
+
+    result_text = output_path.read_text()
+    assert sentinel not in result_text
+
+
+def test_bridge_consults_memory_before_network_research(
+    tmp_path,
+) -> None:
+    events = []
+
+    class OrderedResearch:
+        def research(self, query: str):
+            events.append("network")
+            return FakeResearchClient().research(query)
+
+    class NeverCalledAssistant:
+        async def respond(self, prompt: str, *, session_id: str):
+            raise AssertionError(
+                "assistant should not be reached when memory fails"
+            )
+
+    def unavailable_memory(_query: str) -> str:
+        events.append("memory")
+        raise RuntimeError("memory unavailable")
+
+    bridge = HypercubeResearchBridge(
+        repository_root=tmp_path,
+        model="test-model",
+        ledger_path=tmp_path / "evidence.json",
+        research_client=OrderedResearch(),
+        assistant=NeverCalledAssistant(),
+        memory_context_provider=unavailable_memory,
+    )
+
+    import asyncio
+
+    try:
+        asyncio.run(
+            bridge.run(
+                "research should fail before network",
+                tmp_path / "result.json",
+            )
+        )
+    except Exception as exc:
+        assert "mandatory research memory unavailable" in str(exc)
+    else:
+        raise AssertionError(
+            "mandatory research memory failure did not fail closed"
+        )
+
+    assert events == ["memory"]

--- a/tests/garvis/test_resilient_runtime.py
+++ b/tests/garvis/test_resilient_runtime.py
@@ -137,3 +137,161 @@ async def test_failed_model_call_preserves_user_input() -> None:
     assert ledger.turns == [
         {"role": "user", "content": "survive the crash"},
     ]
+
+
+# RESILIENT REMOTE CANONICAL RESEARCH MEMORY TESTS
+
+@pytest.mark.asyncio
+async def test_resilient_research_memory_is_transient_system_context() -> None:
+    sentinel = "RESILIENT_RESEARCH_MEMORY_SENTINEL_817"
+
+    ledger = FakeLedger()
+    model = CapturingModel("research answer")
+    provider_calls: list[tuple[str, str]] = []
+
+    def memory_provider(
+        query: str,
+        session_id: str,
+    ) -> str:
+        provider_calls.append((query, session_id))
+        return sentinel
+
+    runtime = ResilientGarvisRuntime(
+        model="test-model",
+        session_name="research-session",
+        repository_root=Path.cwd(),
+        client=object(),
+        ledger=ledger,
+        build_messages=fake_build_context,
+        call_model=model,
+        research_memory_provider=memory_provider,
+    )
+
+    prompt = "Research current Python release changes"
+
+    reply = await runtime.respond(prompt)
+
+    assert reply.text == "research answer"
+
+    assert provider_calls == [
+        (prompt, "research-session")
+    ]
+
+    assert ledger.turns == [
+        {"role": "user", "content": prompt},
+        {"role": "assistant", "content": "research answer"},
+    ]
+
+    assert sentinel not in str(ledger.turns)
+
+    assert sentinel in model.messages[0]["content"]
+    assert "ADVISORY CONTEXT ONLY" in (
+        model.messages[0]["content"]
+    )
+
+    user_messages = [
+        item["content"]
+        for item in model.messages
+        if item.get("role") == "user"
+    ]
+
+    assert user_messages[-1] == prompt
+    assert sentinel not in user_messages[-1]
+
+
+@pytest.mark.asyncio
+async def test_resilient_memory_failure_blocks_model_inference() -> None:
+    ledger = FakeLedger()
+    model = CapturingModel("must not execute")
+
+    def unavailable_memory(
+        query: str,
+        session_id: str,
+    ) -> str:
+        del query, session_id
+        raise RuntimeError("memory unavailable")
+
+    runtime = ResilientGarvisRuntime(
+        model="test-model",
+        session_name="research-session",
+        repository_root=Path.cwd(),
+        client=object(),
+        ledger=ledger,
+        build_messages=fake_build_context,
+        call_model=model,
+        research_memory_provider=unavailable_memory,
+    )
+
+    prompt = "Research current lattice evidence"
+
+    with pytest.raises(
+        RuntimeError,
+        match="mandatory research memory unavailable",
+    ):
+        await runtime.respond(prompt)
+
+    assert model.messages == []
+
+    assert ledger.turns == [
+        {"role": "user", "content": prompt}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_resilient_nonresearch_does_not_consult_research_memory() -> None:
+    ledger = FakeLedger()
+    model = CapturingModel("ordinary answer")
+    provider_calls: list[str] = []
+
+    def memory_provider(
+        query: str,
+        session_id: str,
+    ) -> str:
+        provider_calls.append(query + session_id)
+        return "should not be used"
+
+    runtime = ResilientGarvisRuntime(
+        model="test-model",
+        session_name="ordinary-session",
+        repository_root=Path.cwd(),
+        client=object(),
+        ledger=ledger,
+        build_messages=fake_build_context,
+        call_model=model,
+        research_memory_provider=memory_provider,
+    )
+
+    await runtime.respond(
+        "Explain how drywall compound cures"
+    )
+
+    assert provider_calls == []
+
+
+
+@pytest.mark.asyncio
+async def test_resilient_recent_change_phrase_requires_research_memory() -> None:
+    ledger = FakeLedger()
+    model = CapturingModel("research answer")
+    calls: list[str] = []
+
+    def provider(query: str, session_id: str) -> str:
+        calls.append(query)
+        return "ADVISORY_MEMORY_CONTEXT"
+
+    runtime = ResilientGarvisRuntime(
+        model="test-model",
+        session_name="classifier-regression",
+        repository_root=Path.cwd(),
+        client=object(),
+        ledger=ledger,
+        build_messages=fake_build_context,
+        call_model=model,
+        research_memory_provider=provider,
+    )
+
+    prompt = "What changed recently in OpenAI API documentation?"
+
+    await runtime.respond(prompt)
+
+    assert calls == [prompt]


### PR DESCRIPTION
## Canonical research-memory runtime

This PR promotes canonical GARVIS memory into research-like reasoning paths while preserving the project epistemic and authority boundaries.

### Governed artifact

- Exact head commit: `6af9a455a0986c4ad2531e0737e7460cc4e24984`
- Security-reviewed patch SHA-256: `fdc85d4f8fda5cd19406e2149b441c4c759c07941795ed5e592c021008b71151`
- Observed `origin/main` at PR publication: `c362abdde6681b8e59a59a84298d7179ff9681d1`
- Classification: **VERIFIED_PROTOTYPE**

### Verified prototype evidence

- 145 scoped tests passed.
- Canonical research-memory classification is shared across audited local and remote reasoning paths.
- Remote memory is transient model context rather than durable injected user history.
- Mandatory research-memory failure blocks provider inference.
- Network authorization classification remains separate and unchanged.
- Memory does not become retrieved source evidence.
- Memory does not grant execution authority.
- Model output remains candidate reasoning rather than self-certifying evidence.

### Governance

This PR publication is authorized by Adrien D. Thomas.

PR publication does **not** itself authorize merge or deployment.
Exact SHA governs subsequent approval.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added research-aware memory handling for information-seeking and current-event requests.
  * Research context is clearly marked as advisory and kept separate from verified evidence.
  * Added memory controls for prospective, simulation, contradiction, and foreground-review scenarios.
  * Requests requiring research memory now fail safely when that context is unavailable.

* **Documentation**
  * Added architecture, governance, security, provenance, contribution, research-policy, roadmap, citation, and changelog documentation.

* **Tests**
  * Expanded coverage for research memory, evidence boundaries, failure handling, and proposal eligibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->