### PR TITLE
fix(ci): persist brain-gate predictions and close the witness chain

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,5 @@
 # GARVIS Testing Workflow
-# Ensure truthful code validation and CI checks.
+# Witness law: FREEZE prediction before measuring. Same job, same label.
 
 name: Tests
 
@@ -8,7 +8,6 @@ on:
     branches:
       - main
   pull_request:
-    # All PRs, including stacked PRs
 
 env:
   UV_FROZEN: "1"
@@ -23,7 +22,7 @@ jobs:
         run: |
           python3 ci-fix-bot/brain_gate.py predict \
             --agent tests \
-            --label "test-${{ github.run_id }}" \
+            --label "lint-${{ github.run_id }}" \
             --predicted 1.0 \
             --confidence 0.9
       - name: Setup uv
@@ -34,6 +33,14 @@ jobs:
         run: make sync
       - name: Run lint
         run: make lint
+      - name: Brain gate — observe & falsify
+        if: always()
+        run: |
+          python3 ci-fix-bot/brain_gate.py observe \
+            --agent tests \
+            --label "lint-${{ github.run_id }}" \
+            --observed "${{ (job.status == 'success' && 1.0) || 0.0 }}" || true
+          python3 ci-fix-bot/brain_gate.py falsify --agent tests || true
 
   typecheck:
     runs-on: ubuntu-latest
@@ -51,8 +58,6 @@ jobs:
 
   tests:
     runs-on: ubuntu-latest
-    env:
-      OPENAI_API_KEY: fake-for-tests
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -65,13 +70,10 @@ jobs:
       - name: Run tests with coverage
         run: make coverage
 
-
   garvis-tests:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    env:
-      OPENAI_API_KEY: fake-for-tests
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -107,8 +109,6 @@ jobs:
 
   build-docs:
     runs-on: ubuntu-latest
-    env:
-      OPENAI_API_KEY: fake-for-tests
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -123,11 +123,16 @@ jobs:
 
   old_versions:
     runs-on: ubuntu-latest
-    env:
-      OPENAI_API_KEY: fake-for-tests
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Brain gate — predict
+        run: |
+          python3 ci-fix-bot/brain_gate.py predict \
+            --agent tests \
+            --label "old-versions-${{ github.run_id }}" \
+            --predicted 1.0 \
+            --confidence 0.9
       - name: Setup uv
         uses: astral-sh/setup-uv@v5
         with:
@@ -141,6 +146,6 @@ jobs:
         run: |
           python3 ci-fix-bot/brain_gate.py observe \
             --agent tests \
-            --label "test-${{ github.run_id }}" \
+            --label "old-versions-${{ github.run_id }}" \
             --observed "${{ (job.status == 'success' && 1.0) || 0.0 }}" || true
           python3 ci-fix-bot/brain_gate.py falsify --agent tests || true

--- a/ci-fix-bot/garvis_brain_adapter.py
+++ b/ci-fix-bot/garvis_brain_adapter.py
@@ -232,8 +232,50 @@ class BrainAdapter:
             "agi": "NOT_ESTABLISHED",
             "consciousness": "NOT_ESTABLISHED",
             "new_physics": "NOT_ESTABLISHED",
-            "note": "Mathematical consistency and software PASS do not establish physical truth.",
+            "value_authority": "HUMAN_CREATOR_LAW",
+            "theology_status": "VALUE_GUIDANCE_NOT_PHYSICAL_PROOF",
+            "note": "Mathematical consistency and software PASS do not establish physical truth. Faith and identity may guide values and approval; they are not treated as laboratory evidence.",
         }
+
+
+    def _agent_record(self) -> dict[str, Any]:
+        agent_key = self.agent_name
+        if agent_key not in self._ledger["agents"]:
+            self._ledger["agents"][agent_key] = {
+                "observations": [],
+                "pending_predictions": {},
+                "total": 0,
+                "confirmed": 0,
+                "falsified": 0,
+                "indeterminate": 0,
+            }
+        record = self._ledger["agents"][agent_key]
+        record.setdefault("pending_predictions", {})
+        return record
+
+    def _store_pending_prediction(self, pred: "AgentPrediction") -> None:
+        """Freeze prediction to disk before measurement. Memory is not authority."""
+        record = self._agent_record()
+        record["pending_predictions"][pred.label] = {
+            "predicted": pred.predicted,
+            "confidence": pred.confidence,
+            "timestamp": pred.timestamp,
+        }
+        self._save_ledger()
+
+    def _consume_pending_prediction(self, label: str) -> "AgentPrediction | None":
+        record = self._agent_record()
+        pending = record.get("pending_predictions", {}).pop(label, None)
+        if pending is None:
+            return None
+        self._save_ledger()
+        return AgentPrediction(
+            label=label,
+            predicted=float(pending.get("predicted", 0.5)),
+            confidence=float(pending.get("confidence", 0.5)),
+            agent_name=self.agent_name,
+            timestamp=float(pending.get("timestamp", time.time())),
+        )
 
     def predict(self, label: str, predicted: float, confidence: float = 0.9) -> AgentPrediction:
         """Record a prediction before the bot acts."""
@@ -247,6 +289,7 @@ class BrainAdapter:
             agent_name=self.agent_name,
         )
         self.predictions[label] = pred
+        self._store_pending_prediction(pred)
         return pred
 
     def observe(
@@ -260,12 +303,16 @@ class BrainAdapter:
 
         pred = self.predictions.get(label)
         if pred is None:
+            pred = self._consume_pending_prediction(label)
+
+        if pred is None:
             # No prediction recorded — use neutral defaults
             A = 0.5
             O = 0.5
         else:
             A = pred.predicted
             O = pred.confidence
+            self.predictions.pop(label, None)
 
         B = observed
         delta_theta = phase
@@ -480,5 +527,7 @@ def epistemic_boundary() -> dict[str, str]:
         "agi": "NOT_ESTABLISHED",
         "consciousness": "NOT_ESTABLISHED",
         "new_physics": "NOT_ESTABLISHED",
-        "note": "Mathematical consistency and software PASS do not establish physical truth.",
+        "value_authority": "HUMAN_CREATOR_LAW",
+        "theology_status": "VALUE_GUIDANCE_NOT_PHYSICAL_PROOF",
+        "note": "Mathematical consistency and software PASS do not establish physical truth. Faith and identity may guide values and approval; they are not treated as laboratory evidence.",
     }


### PR DESCRIPTION
- predict() freezes A/O to ledger pending_predictions
- observe() recovers freeze across process boundaries
- lint and old_versions use same-job predict→observe
- epistemic: HUMAN_CREATOR_LAW + VALUE_GUIDANCE_NOT_PHYSICAL_PROOF
- Lattice Law remains HYPOTHESIS_UNDER_TEST
- Scope: brain-gate + tests.yml only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation reliability by preserving predictions across processing steps and restoring them when needed.
  - Clarified the distinction between faith-based guidance and laboratory evidence in recorded results.

- **Chores**
  - Updated automated checks with additional prediction, observation, and verification steps.
  - Removed placeholder credentials from testing and documentation workflows.
  - Improved consistency in validation labels and workflow descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->