### PR TITLE
feat(garvis): add governed FlexAI HTTP adapter

### DIFF
--- a/src/garvis/flexai_backend.py
+++ b/src/garvis/flexai_backend.py
@@ -1,0 +1,170 @@
+"""GARVIS-owned FlexAI HTTPS inference adapter.
+
+Creator / conceptual architecture: Adrien D. Thomas / ProCityHub.
+
+Boundary:
+- GARVIS retains routing, memory, governance, evidence, and tool authority.
+- FlexAI is an interchangeable remote inference engine only.
+- This module does not import OpenAI, Agents SDK, LangChain, LangGraph, or a
+  FlexAI agent framework.
+- Provider output is candidate information and never self-verifying truth.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Mapping, Optional, Sequence
+
+import requests
+
+
+FLEXAI_API_KEY_ENV = "FLEXAI_API_KEY"
+FLEXAI_BASE_URL = "https://api.flex.ai/v1"
+FLEXAI_CHAT_COMPLETIONS_URL = FLEXAI_BASE_URL + "/chat/completions"
+
+
+class FlexAIConfigurationError(RuntimeError):
+    """Raised before transport when FlexAI configuration is invalid."""
+
+
+class FlexAITransportError(RuntimeError):
+    """Raised when the remote transport fails without exposing response bodies."""
+
+
+class FlexAIResponseError(RuntimeError):
+    """Raised when FlexAI returns an unusable response shape."""
+
+
+@dataclass(frozen=True)
+class FlexAIResult:
+    """Normalized candidate output plus preserved raw provider JSON."""
+
+    model: str
+    text: str
+    raw: Mapping[str, Any]
+
+
+def _bare_model(model: object) -> str:
+    if not isinstance(model, str):
+        raise FlexAIConfigurationError("FlexAI model identifier must be a string")
+
+    clean = model.strip()
+    prefix = "flexai/"
+    if not clean.casefold().startswith(prefix):
+        raise FlexAIConfigurationError(
+            "FlexAI model identifier must use the explicit flexai/ namespace"
+        )
+
+    bare = clean[len(prefix):].strip()
+    if not bare:
+        raise FlexAIConfigurationError("FlexAI model identifier is empty")
+    return bare
+
+
+def is_flexai_model(model: object) -> bool:
+    if not isinstance(model, str):
+        return False
+    return model.strip().casefold().startswith("flexai/")
+
+
+def _resolve_api_key(env: Optional[Mapping[str, str]]) -> str:
+    source = os.environ if env is None else env
+    value = (source.get(FLEXAI_API_KEY_ENV) or "").strip()
+    if not value:
+        raise FlexAIConfigurationError(
+            "FLEXAI_API_KEY is not set for the FlexAI provider"
+        )
+    return value
+
+
+def _normalize_messages(
+    messages: Sequence[Mapping[str, Any]],
+) -> list[Dict[str, Any]]:
+    normalized = []
+    for message in messages:
+        if not isinstance(message, Mapping):
+            raise FlexAIConfigurationError("each message must be a mapping")
+        normalized.append(dict(message))
+
+    if not normalized:
+        raise FlexAIConfigurationError("at least one message is required")
+    return normalized
+
+
+def chat_completion(
+    model: str,
+    messages: Sequence[Mapping[str, Any]],
+    *,
+    env: Optional[Mapping[str, str]] = None,
+    timeout: float = 30.0,
+    post: Optional[Callable[..., Any]] = None,
+) -> FlexAIResult:
+    """Send one governed chat-completions request.
+
+    ``post`` exists for deterministic offline testing. Production callers may
+    omit it, in which case ``requests.post`` is used.
+    """
+
+    bare_model = _bare_model(model)
+    api_key = _resolve_api_key(env)
+
+    if timeout <= 0:
+        raise FlexAIConfigurationError("timeout must be greater than zero")
+
+    payload = {
+        "model": bare_model,
+        "messages": _normalize_messages(messages),
+    }
+    headers = {
+        "Authorization": "Bearer " + api_key,
+        "Content-Type": "application/json",
+    }
+
+    transport = requests.post if post is None else post
+
+    try:
+        response = transport(
+            FLEXAI_CHAT_COMPLETIONS_URL,
+            headers=headers,
+            json=payload,
+            timeout=timeout,
+        )
+    except requests.RequestException as exc:
+        raise FlexAITransportError("FlexAI request transport failed") from exc
+
+    status_code = int(getattr(response, "status_code", 0) or 0)
+    if status_code < 200 or status_code >= 300:
+        raise FlexAITransportError(
+            "FlexAI returned HTTP status {}".format(status_code)
+        )
+
+    try:
+        data = response.json()
+    except (TypeError, ValueError) as exc:
+        raise FlexAIResponseError("FlexAI response was not valid JSON") from exc
+
+    if not isinstance(data, Mapping):
+        raise FlexAIResponseError("FlexAI response root must be an object")
+
+    choices = data.get("choices")
+    if not isinstance(choices, list) or not choices:
+        raise FlexAIResponseError("FlexAI response contained no choices")
+
+    first = choices[0]
+    if not isinstance(first, Mapping):
+        raise FlexAIResponseError("FlexAI choice must be an object")
+
+    message = first.get("message")
+    if not isinstance(message, Mapping):
+        raise FlexAIResponseError("FlexAI choice contained no message")
+
+    content = message.get("content")
+    if not isinstance(content, str):
+        raise FlexAIResponseError("FlexAI message content must be text")
+
+    return FlexAIResult(
+        model=bare_model,
+        text=content,
+        raw=dict(data),
+    )

--- a/src/garvis/universal_ai_registry.py
+++ b/src/garvis/universal_ai_registry.py
@@ -34,6 +34,7 @@ class AdapterKind(str, Enum):
     OPENAI_NATIVE = "openai_native"
     ANTHROPIC_NATIVE = "anthropic_native"
     OPENAI_COMPATIBLE = "openai_compatible"
+    FLEXAI_HTTP = "flexai_http"
     MANUAL_ONLY = "manual_only"
     MISSING = "missing"
     UNKNOWN = "unknown"
@@ -105,6 +106,13 @@ def identify_provider(model: str) -> ProviderIdentity:
             provider_id="garvis",
             adapter=AdapterKind.GARVIS_LOCAL,
             adapter_supported=True,
+        )
+
+    if lowered.startswith("flexai/"):
+        return ProviderIdentity(
+            provider_id="flexai",
+            adapter=AdapterKind.FLEXAI_HTTP,
+            required_env_names=("FLEXAI_API_KEY",),
         )
 
     if lowered.startswith("anthropic/") or lowered.startswith("claude-") or lowered.startswith("claude/"):

--- a/tests/garvis/test_flexai_backend.py
+++ b/tests/garvis/test_flexai_backend.py
@@ -1,0 +1,154 @@
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+from garvis.flexai_backend import (
+    FLEXAI_CHAT_COMPLETIONS_URL,
+    FlexAIConfigurationError,
+    FlexAIResponseError,
+    FlexAITransportError,
+    chat_completion,
+)
+
+
+class FakeResponse:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self):
+        return self._payload
+
+
+def test_missing_key_fails_before_transport():
+    called = {"value": False}
+
+    def fake_post(*args, **kwargs):
+        called["value"] = True
+        raise AssertionError("transport must not execute")
+
+    with pytest.raises(FlexAIConfigurationError, match="FLEXAI_API_KEY"):
+        chat_completion(
+            "flexai/test-model",
+            [{"role": "user", "content": "hello"}],
+            env={},
+            post=fake_post,
+        )
+
+    assert called["value"] is False
+
+
+def test_explicit_namespace_and_empty_identifier_fail_closed():
+    with pytest.raises(FlexAIConfigurationError):
+        chat_completion(
+            "vendor/test-model",
+            [{"role": "user", "content": "hello"}],
+            env={"FLEXAI_API_KEY": "test-key"},
+            post=lambda *a, **k: None,
+        )
+
+    with pytest.raises(FlexAIConfigurationError, match="empty"):
+        chat_completion(
+            "flexai/",
+            [{"role": "user", "content": "hello"}],
+            env={"FLEXAI_API_KEY": "test-key"},
+            post=lambda *a, **k: None,
+        )
+
+
+def test_request_contract_and_raw_response_preserved():
+    secret = "test-flexai-key-not-real"
+    captured = {}
+
+    def fake_post(url, *, headers, json, timeout):
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["json"] = json
+        captured["timeout"] = timeout
+        return FakeResponse(
+            {
+                "id": "offline-fixture",
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": "candidate answer",
+                        }
+                    }
+                ],
+            }
+        )
+
+    result = chat_completion(
+        "flexai/example-model",
+        [{"role": "user", "content": "test"}],
+        env={"FLEXAI_API_KEY": secret},
+        timeout=12.5,
+        post=fake_post,
+    )
+
+    assert captured["url"] == FLEXAI_CHAT_COMPLETIONS_URL
+    assert captured["url"] == "https://api.flex.ai/v1/chat/completions"
+    assert captured["headers"]["Authorization"] == "Bearer " + secret
+    assert captured["headers"]["Content-Type"] == "application/json"
+    assert captured["json"] == {
+        "model": "example-model",
+        "messages": [{"role": "user", "content": "test"}],
+    }
+    assert secret not in json.dumps(captured["json"], sort_keys=True)
+    assert captured["timeout"] == 12.5
+
+    assert result.model == "example-model"
+    assert result.text == "candidate answer"
+    assert result.raw["id"] == "offline-fixture"
+
+
+def test_http_error_does_not_echo_secret_or_response_body():
+    secret = "secret-that-must-not-leak"
+
+    def fake_post(*args, **kwargs):
+        return FakeResponse(
+            {"error": "provider body should remain unreported"},
+            status_code=503,
+        )
+
+    with pytest.raises(FlexAITransportError) as excinfo:
+        chat_completion(
+            "flexai/example-model",
+            [{"role": "user", "content": "test"}],
+            env={"FLEXAI_API_KEY": secret},
+            post=fake_post,
+        )
+
+    message = str(excinfo.value)
+    assert secret not in message
+    assert "provider body should remain unreported" not in message
+    assert "503" in message
+
+
+def test_invalid_provider_json_shape_fails_closed():
+    with pytest.raises(FlexAIResponseError):
+        chat_completion(
+            "flexai/example-model",
+            [{"role": "user", "content": "test"}],
+            env={"FLEXAI_API_KEY": "test-key"},
+            post=lambda *a, **k: FakeResponse({"choices": []}),
+        )
+
+
+def test_backend_imports_no_agent_or_provider_sdk():
+    source = Path("src/garvis/flexai_backend.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    imported_roots = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_roots.update(alias.name.split(".", 1)[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported_roots.add(node.module.split(".", 1)[0])
+
+    assert imported_roots.isdisjoint(
+        {"openai", "agents", "langchain", "langgraph", "flexai"}
+    )

--- a/tests/garvis/test_universal_ai_router_security.py
+++ b/tests/garvis/test_universal_ai_router_security.py
@@ -56,6 +56,7 @@ def test_explicit_openai_names_still_route_to_openai():
 
 def test_known_provider_families_still_route():
     expected = {
+        "flexai/test": "flexai",
         "anthropic/claude-test": "anthropic",
         "claude-sonnet-test": "anthropic",
         "claude/test": "anthropic",
@@ -107,3 +108,38 @@ def test_android_app_cannot_self_declare_programmable_adapter():
         assert "verified integration adapter" in str(exc)
     else:
         raise AssertionError("unverified Android app became programmable")
+
+
+def test_flexai_identity_requires_explicit_namespace_and_stays_candidate_only():
+    identity = identify_provider("flexai/example-model")
+    assert identity.provider_id == "flexai"
+    assert identity.adapter is AdapterKind.FLEXAI_HTTP
+    assert identity.required_env_names == ("FLEXAI_API_KEY",)
+    assert identity.adapter_supported is True
+
+    organ = remote_model_organ(
+        "flexai/example-model",
+        env={"FLEXAI_API_KEY": "secret-flexai"},
+    )
+    assert organ.configured is True
+    assert organ.programmable is True
+    assert organ.authority is Authority.CANDIDATE_ONLY
+
+
+def test_flexai_key_cannot_create_identity_or_leak_from_safe_report():
+    secret = "flexai-secret-value"
+    registry = build_registry(
+        ["totally-unknown-model", "flexai/example-model"],
+        env={"FLEXAI_API_KEY": secret},
+    )
+
+    unknown = [
+        item
+        for item in registry.all()
+        if item.model == "totally-unknown-model"
+    ][0]
+    assert unknown.provider_id == "unknown"
+    assert unknown.programmable is False
+
+    encoded = json.dumps(registry.safe_report(), sort_keys=True)
+    assert secret not in encoded


### PR DESCRIPTION
## Summary
Adds a ProCityHub-owned FlexAI HTTP inference adapter while preserving GARVIS authority boundaries.

## Verified evidence
- Exact commit: `7b0b0f774129c23a8ed70c17b1986cab55fb00ff`
- 39 scoped offline tests passed
- Static security review passed
- Fixed endpoint: `https://api.flex.ai/v1/chat/completions`
- FlexAI remains `CANDIDATE_ONLY`
- No OpenAI Agents SDK, LangChain, LangGraph, or FlexAI Agent SDK imports in the adapter
- No live FlexAI request performed

## Scope
Exactly four files:
- `src/garvis/flexai_backend.py`
- `src/garvis/universal_ai_registry.py`
- `tests/garvis/test_flexai_backend.py`
- `tests/garvis/test_universal_ai_router_security.py`

## Governance
Draft PR only. Merge, deployment, installation, and live FlexAI connectivity remain separately gated.